### PR TITLE
refactor: change naming scheme of space tokens

### DIFF
--- a/packages/foundation/atomic-playfulness.tokens.json
+++ b/packages/foundation/atomic-playfulness.tokens.json
@@ -4,15 +4,15 @@
     "$description": "Space scale to be used for white-space.",
 
     "none": { "$value": "0rem" },
-    "xxxSmall": { "$value": "0.125rem" },
-    "xxSmall": { "$value": "0.25rem" },
-    "xSmall": { "$value": "0.5rem" },
-    "small": { "$value": "0.75rem" },
-    "medium": { "$value": "1rem" },
-    "large": { "$value": "1.5rem" },
-    "xLarge": { "$value": "2rem" },
-    "xxLarge": { "$value": "3rem" },
-    "xxxLarge": { "$value": "4rem" }
+    "3xs": { "$value": "0.125rem" },
+    "2xs": { "$value": "0.25rem" },
+    "xs": { "$value": "0.5rem" },
+    "s": { "$value": "0.75rem" },
+    "m": { "$value": "1rem" },
+    "l": { "$value": "1.5rem" },
+    "xl": { "$value": "2rem" },
+    "2xl": { "$value": "3rem" },
+    "3xl": { "$value": "4rem" }
   },
   "font": {
     "family": {


### PR DESCRIPTION
This PR adjust the naming scheme of space tokens to make them more compact.

```css
--hap-space-xxxSmall --> hap-space-3xs
```