### PR TITLE
feature(tokens): add design tokens exported from Figma variables

### DIFF
--- a/.changeset/tender-planets-develop.md
+++ b/.changeset/tender-planets-develop.md
@@ -1,0 +1,5 @@
+---
+"@holisticon/hap-foundation": minor
+---
+
+Added design tokens that are extracted directly from our Figma reference library.

--- a/packages/documentation/src/design-tokens/color.mdx
+++ b/packages/documentation/src/design-tokens/color.mdx
@@ -98,3 +98,26 @@ of an application.
     }}
   />
 </ColorPalette>
+
+## Base Colors
+
+Tones of black and whites that are mainly used for typography.
+
+<ColorPalette>
+  <ColorItem
+    title="Base Black"
+    colors={{
+      primary: "var(--hap-primitives-color-base-blackprimary)",
+      secondary: "var(--hap-primitives-color-base-blacksecondary)",
+      tertiary: "var(--hap-primitives-color-base-blacktertiary)",
+    }}
+  />
+  <ColorItem
+    title="Base White"
+    colors={{
+      primary: "var(--hap-primitives-color-base-whiteprimary)",
+      secondary: "var(--hap-primitives-color-base-whitesecondary)",
+      tertiary: "var(--hap-primitives-color-base-whitetertiary)",
+    }}
+  />
+</ColorPalette>

--- a/packages/documentation/src/design-tokens/color.mdx
+++ b/packages/documentation/src/design-tokens/color.mdx
@@ -2,48 +2,99 @@ import { ColorPalette, ColorItem } from "@storybook/blocks";
 
 # Color Tokens
 
-The following color tokens are available as CSS custom properties. In each
-palette, the `500` variant is considered a primary color. An exception is
-`forest-green-700`, which is also a primary color that is used as a text color.
+The following color tokens are available as CSS custom properties.
+
+## Primitive Brand Colors
+
+Palettes for our brand colors.
 
 <ColorPalette>
   <ColorItem
-    title="Forest Green"
-    subtitle="Primary Color Palette"
+    title="Brand"
+    subtitle="Brand Colors"
     colors={{
-      100: "var(--hap-color-forest-green-100)",
-      200: "var(--hap-color-forest-green-200)",
-      300: "var(--hap-color-forest-green-300)",
-      400: "var(--hap-color-forest-green-400)",
-      500: "var(--hap-color-forest-green-500)",
-      600: "var(--hap-color-forest-green-600)",
-      700: "var(--hap-color-forest-green-700)",
+      50: "var(--hap-primitives-color-brand-50)",
+      100: "var(--hap-primitives-color-brand-100)",
+      200: "var(--hap-primitives-color-brand-200)",
+      300: "var(--hap-primitives-color-brand-300)",
+      400: "var(--hap-primitives-color-brand-400)",
+      500: "var(--hap-primitives-color-brand-500)",
+      600: "var(--hap-primitives-color-brand-600)",
+      700: "var(--hap-primitives-color-brand-700)",
+      800: "var(--hap-primitives-color-brand-800)",
+      900: "var(--hap-primitives-color-brand-900)",
     }}
   />
   <ColorItem
-    title="Blue Gray"
-    subtitle="Accent Color Palette"
-    colors={{
-      300: "var(--hap-color-blue-gray-300)",
-      400: "var(--hap-color-blue-gray-400)",
-      500: "var(--hap-color-blue-gray-500)",
-      600: "var(--hap-color-blue-gray-600)",
-      700: "var(--hap-color-blue-gray-700)",
-    }}
-  />
-  <ColorItem
-    title="Bright Green"
-    subtitle="Hope you wear sunglasses..."
-    colors={{
-      500: "var(--hap-color-bright-green-500)",
-    }}
-  />
-  <ColorItem
-    title="Neutrals"
+    title="Neutral"
     subtitle="Neutral Colors"
     colors={{
-      White: "var(--hap-color-neutral-white)",
-      Black: "var(--hap-color-neutral-black)",
+      50: "var(--hap-primitives-color-neutral-50)",
+      100: "var(--hap-primitives-color-neutral-100)",
+      200: "var(--hap-primitives-color-neutral-200)",
+      300: "var(--hap-primitives-color-neutral-300)",
+      400: "var(--hap-primitives-color-neutral-400)",
+      500: "var(--hap-primitives-color-neutral-500)",
+      600: "var(--hap-primitives-color-neutral-600)",
+      700: "var(--hap-primitives-color-neutral-700)",
+      800: "var(--hap-primitives-color-neutral-800)",
+      900: "var(--hap-primitives-color-neutral-900)",
+    }}
+  />
+</ColorPalette>
+
+## Primitive Feedback Colors
+
+Palettes for our feedback colors which are used to inform users about the state
+of an application.
+
+<ColorPalette>
+  <ColorItem
+    title="Feedback Green"
+    subtitle="Give some positive feedback"
+    colors={{
+      50: "var(--hap-primitives-color-feedback-green-50)",
+      100: "var(--hap-primitives-color-feedback-green-100)",
+      200: "var(--hap-primitives-color-feedback-green-200)",
+      300: "var(--hap-primitives-color-feedback-green-300)",
+      400: "var(--hap-primitives-color-feedback-green-400)",
+      500: "var(--hap-primitives-color-feedback-green-500)",
+      600: "var(--hap-primitives-color-feedback-green-600)",
+      700: "var(--hap-primitives-color-feedback-green-700)",
+      800: "var(--hap-primitives-color-feedback-green-800)",
+      900: "var(--hap-primitives-color-feedback-green-900)",
+    }}
+  />
+  <ColorItem
+    title="Feedback Red"
+    subtitle="Give some critical feedback"
+    colors={{
+      50: "var(--hap-primitives-color-feedback-red-50)",
+      100: "var(--hap-primitives-color-feedback-red-100)",
+      200: "var(--hap-primitives-color-feedback-red-200)",
+      300: "var(--hap-primitives-color-feedback-red-300)",
+      400: "var(--hap-primitives-color-feedback-red-400)",
+      500: "var(--hap-primitives-color-feedback-red-500)",
+      600: "var(--hap-primitives-color-feedback-red-600)",
+      700: "var(--hap-primitives-color-feedback-red-700)",
+      800: "var(--hap-primitives-color-feedback-red-800)",
+      900: "var(--hap-primitives-color-feedback-red-900)",
+    }}
+  />
+  <ColorItem
+    title="Feedback Yellow"
+    subtitle="Give some cautious feedback"
+    colors={{
+      50: "var(--hap-primitives-color-feedback-yellow-50)",
+      100: "var(--hap-primitives-color-feedback-yellow-100)",
+      200: "var(--hap-primitives-color-feedback-yellow-200)",
+      300: "var(--hap-primitives-color-feedback-yellow-300)",
+      400: "var(--hap-primitives-color-feedback-yellow-400)",
+      500: "var(--hap-primitives-color-feedback-yellow-500)",
+      600: "var(--hap-primitives-color-feedback-yellow-600)",
+      700: "var(--hap-primitives-color-feedback-yellow-700)",
+      800: "var(--hap-primitives-color-feedback-yellow-800)",
+      900: "var(--hap-primitives-color-feedback-yellow-900)",
     }}
   />
 </ColorPalette>

--- a/packages/foundation/atomic-playfulness.tokens.json
+++ b/packages/foundation/atomic-playfulness.tokens.json
@@ -1,147 +1,537 @@
 {
   "Primitives": {
     "color": {
-      "green": {
-        "100": {
-          "$type": "color",
-          "$value": "#d6f2e5",
-          "$description": "",
-          "$extensions": {
-            "mode": {},
-            "figma": {
-              "variableId": "VariableID:39:2433",
-              "collection": {
-                "id": "VariableCollectionId:2:5",
-                "name": "Primitives",
-                "defaultModeId": "2:0"
+      "feedback": {
+        "green": {
+          "50": {
+            "$type": "color",
+            "$value": "#effdf4",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:352:1377",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "100": {
+            "$type": "color",
+            "$value": "#dbf6e9",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2433",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "200": {
+            "$type": "color",
+            "$value": "#99eac4",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2431",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "300": {
+            "$type": "color",
+            "$value": "#62e1a5",
+            "$description": "Brand Color: Forest Green B4",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:2:8",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "400": {
+            "$type": "color",
+            "$value": "#3dce8a",
+            "$description": "Brand Color: Forest Green B3",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:2:11",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "500": {
+            "$type": "color",
+            "$value": "#18b169",
+            "$description": "Brand Color: Forest Green B2",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:2:9",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "600": {
+            "$type": "color",
+            "$value": "#089455",
+            "$description": "Brand Color: Forest Green B1",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:2:10",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "700": {
+            "$type": "color",
+            "$value": "#077342",
+            "$description": "Brand Color: Forest Green",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:2:7",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "800": {
+            "$type": "color",
+            "$value": "#054e30",
+            "$description": "Brand Color: Forest Green D1",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:98",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "900": {
+            "$type": "color",
+            "$value": "#063221",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2432",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "950": {
+            "$type": "color",
+            "$value": "#042f18",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:352:1378",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
               }
             }
           }
         },
-        "200": {
-          "$type": "color",
-          "$value": "#98d2b7",
-          "$description": "",
-          "$extensions": {
-            "mode": {},
-            "figma": {
-              "variableId": "VariableID:39:2431",
-              "collection": {
-                "id": "VariableCollectionId:2:5",
-                "name": "Primitives",
-                "defaultModeId": "2:0"
+        "red": {
+          "50": {
+            "$type": "color",
+            "$value": "#fff3f1",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:352:1373",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "100": {
+            "$type": "color",
+            "$value": "#ffe5e0",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2435",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "200": {
+            "$type": "color",
+            "$value": "#ffcfc6",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:102",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "300": {
+            "$type": "color",
+            "$value": "#ffaf9e",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:103",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "400": {
+            "$type": "color",
+            "$value": "#ff7f67",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:104",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "500": {
+            "$type": "color",
+            "$value": "#fb5738",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:105",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "600": {
+            "$type": "color",
+            "$value": "#eb4b2d",
+            "$description": "Brand Color: Bright Red",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:106",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "700": {
+            "$type": "color",
+            "$value": "#c42d12",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:107",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "800": {
+            "$type": "color",
+            "$value": "#a22911",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:108",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "900": {
+            "$type": "color",
+            "$value": "#872816",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2436",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "950": {
+            "$type": "color",
+            "$value": "#491107",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:352:1374",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
               }
             }
           }
         },
-        "300": {
-          "$type": "color",
-          "$value": "#549a79",
-          "$description": "Brand Color: Forest Green B4",
-          "$extensions": {
-            "mode": {},
-            "figma": {
-              "variableId": "VariableID:2:8",
-              "collection": {
-                "id": "VariableCollectionId:2:5",
-                "name": "Primitives",
-                "defaultModeId": "2:0"
+        "yellow": {
+          "50": {
+            "$type": "color",
+            "$value": "#fdfbe8",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:352:1379",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
               }
             }
-          }
-        },
-        "400": {
-          "$type": "color",
-          "$value": "#478467",
-          "$description": "Brand Color: Forest Green B3",
-          "$extensions": {
-            "mode": {},
-            "figma": {
-              "variableId": "VariableID:2:11",
-              "collection": {
-                "id": "VariableCollectionId:2:5",
-                "name": "Primitives",
-                "defaultModeId": "2:0"
+          },
+          "100": {
+            "$type": "color",
+            "$value": "#fef7c4",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2438",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
               }
             }
-          }
-        },
-        "500": {
-          "$type": "color",
-          "$value": "#396d55",
-          "$description": "Brand Color: Forest Green B2",
-          "$extensions": {
-            "mode": {},
-            "figma": {
-              "variableId": "VariableID:2:9",
-              "collection": {
-                "id": "VariableCollectionId:2:5",
-                "name": "Primitives",
-                "defaultModeId": "2:0"
+          },
+          "200": {
+            "$type": "color",
+            "$value": "#ffec89",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:3",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
               }
             }
-          }
-        },
-        "600": {
-          "$type": "color",
-          "$value": "#285340",
-          "$description": "Brand Color: Forest Green B1",
-          "$extensions": {
-            "mode": {},
-            "figma": {
-              "variableId": "VariableID:2:10",
-              "collection": {
-                "id": "VariableCollectionId:2:5",
-                "name": "Primitives",
-                "defaultModeId": "2:0"
+          },
+          "300": {
+            "$type": "color",
+            "$value": "#fed946",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:4",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
               }
             }
-          }
-        },
-        "700": {
-          "$type": "color",
-          "$value": "#1e4132",
-          "$description": "Brand Color: Forest Green",
-          "$extensions": {
-            "mode": {},
-            "figma": {
-              "variableId": "VariableID:2:7",
-              "collection": {
-                "id": "VariableCollectionId:2:5",
-                "name": "Primitives",
-                "defaultModeId": "2:0"
+          },
+          "400": {
+            "$type": "color",
+            "$value": "#fbc316",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:5",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
               }
             }
-          }
-        },
-        "800": {
-          "$type": "color",
-          "$value": "#10352a",
-          "$description": "Brand Color: Forest Green D1",
-          "$extensions": {
-            "mode": {},
-            "figma": {
-              "variableId": "VariableID:21:98",
-              "collection": {
-                "id": "VariableCollectionId:2:5",
-                "name": "Primitives",
-                "defaultModeId": "2:0"
+          },
+          "500": {
+            "$type": "color",
+            "$value": "#f6b206",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:6",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
               }
             }
-          }
-        },
-        "900": {
-          "$type": "color",
-          "$value": "#102928",
-          "$description": "Brand Color: Black-Green",
-          "$extensions": {
-            "mode": {},
-            "figma": {
-              "variableId": "VariableID:39:2432",
-              "collection": {
-                "id": "VariableCollectionId:2:5",
-                "name": "Primitives",
-                "defaultModeId": "2:0"
+          },
+          "600": {
+            "$type": "color",
+            "$value": "#cb8204",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:7",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "700": {
+            "$type": "color",
+            "$value": "#a35c05",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:8",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "800": {
+            "$type": "color",
+            "$value": "#86480d",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:9",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "900": {
+            "$type": "color",
+            "$value": "#723b10",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2437",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "950": {
+            "$type": "color",
+            "$value": "#421e07",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:352:1380",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
               }
             }
           }
@@ -150,7 +540,7 @@
       "neutral": {
         "50": {
           "$type": "color",
-          "$value": "#ffffff",
+          "$value": "#f5f7f8",
           "$description": "Brand Color: White",
           "$extensions": {
             "mode": {},
@@ -166,7 +556,7 @@
         },
         "100": {
           "$type": "color",
-          "$value": "#f0f8ff",
+          "$value": "#e6eaf6",
           "$description": "Brand Color: Blue-Grey B2",
           "$extensions": {
             "mode": {},
@@ -246,8 +636,8 @@
         },
         "600": {
           "$type": "color",
-          "$value": "#9ca4b8",
-          "$description": "Brand Color: Blue-Grey D2",
+          "$value": "#868ca5",
+          "$description": "",
           "$extensions": {
             "mode": {},
             "figma": {
@@ -262,7 +652,7 @@
         },
         "700": {
           "$type": "color",
-          "$value": "#4c5979",
+          "$value": "#73788f",
           "$description": "",
           "$extensions": {
             "mode": {},
@@ -278,7 +668,7 @@
         },
         "800": {
           "$type": "color",
-          "$value": "#283c5a",
+          "$value": "#5e6275",
           "$description": "Brand Color: Dark Blue",
           "$extensions": {
             "mode": {},
@@ -294,7 +684,7 @@
         },
         "900": {
           "$type": "color",
-          "$value": "#1e2735",
+          "$value": "#505260",
           "$description": "",
           "$extensions": {
             "mode": {},
@@ -310,7 +700,7 @@
         },
         "950": {
           "$type": "color",
-          "$value": "#141419",
+          "$value": "#2e3038",
           "$description": "Brand Color: Black",
           "$extensions": {
             "mode": {},
@@ -325,441 +715,163 @@
           }
         }
       },
-      "accent": {
-        "red": {
-          "100": {
-            "$type": "color",
-            "$value": "#f6e9e6",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:39:2435",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "200": {
-            "$type": "color",
-            "$value": "#f1ccc5",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:21:102",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "300": {
-            "$type": "color",
-            "$value": "#ecab9f",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:21:103",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "400": {
-            "$type": "color",
-            "$value": "#ea735d",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:21:104",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "500": {
-            "$type": "color",
-            "$value": "#eb4b2d",
-            "$description": "Brand Color: Bright Red",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:21:105",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "600": {
-            "$type": "color",
-            "$value": "#bf3b22",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:21:106",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "700": {
-            "$type": "color",
-            "$value": "#8c2815",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:21:107",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "800": {
-            "$type": "color",
-            "$value": "#621e11",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:21:108",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "900": {
-            "$type": "color",
-            "$value": "#51170c",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:39:2436",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+      "brand": {
+        "50": {
+          "$type": "color",
+          "$value": "#ffffff",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:317:4262",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
           }
         },
-        "yellow": {
-          "100": {
-            "$type": "color",
-            "$value": "#f4eadb",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:39:2438",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "200": {
-            "$type": "color",
-            "$value": "#f6e5cb",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:3",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "300": {
-            "$type": "color",
-            "$value": "#e9c791",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:4",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "400": {
-            "$type": "color",
-            "$value": "#e8b768",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:5",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "500": {
-            "$type": "color",
-            "$value": "#eba22d",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:6",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "600": {
-            "$type": "color",
-            "$value": "#c28728",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:7",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "700": {
-            "$type": "color",
-            "$value": "#9d6d1f",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:8",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "800": {
-            "$type": "color",
-            "$value": "#513810",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:9",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "900": {
-            "$type": "color",
-            "$value": "#462f0b",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:39:2437",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+        "100": {
+          "$type": "color",
+          "$value": "#f0ffe6",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:39:2440",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
           }
         },
-        "brand": {
-          "100": {
-            "$type": "color",
-            "$value": "#f0ffe6",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:39:2440",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+        "200": {
+          "$type": "color",
+          "$value": "#dbffc4",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:22:12",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
-          },
-          "200": {
-            "$type": "color",
-            "$value": "#dbffc4",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:12",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": "#c8ffa5",
+          "$description": "Brand Color: Bright Green",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:22:13",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
-          },
-          "300": {
-            "$type": "color",
-            "$value": "#c8ffa5",
-            "$description": "Brand Color: Bright Green",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:13",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": "#a7eb7c",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:22:14",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
-          },
-          "400": {
-            "$type": "color",
-            "$value": "#a7eb7c",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:14",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": "#1ec866",
+          "$description": "Brand Color: Vivid Green",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:22:15",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
-          },
-          "500": {
-            "$type": "color",
-            "$value": "#1ec866",
-            "$description": "Brand Color: Vivid Green",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:15",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": "#239d58",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:22:16",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
-          },
-          "600": {
-            "$type": "color",
-            "$value": "#239d58",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:16",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": "#217846",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:22:17",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
-          },
-          "700": {
-            "$type": "color",
-            "$value": "#217846",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:17",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": "#193d36",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:22:18",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
-          },
-          "800": {
-            "$type": "color",
-            "$value": "#1a5448",
-            "$description": "",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:22:18",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
-              }
-            }
-          },
-          "900": {
-            "$type": "color",
-            "$value": "#102924",
-            "$description": "Brand Color: Black-Green",
-            "$extensions": {
-              "mode": {},
-              "figma": {
-                "variableId": "VariableID:39:2439",
-                "collection": {
-                  "id": "VariableCollectionId:2:5",
-                  "name": "Primitives",
-                  "defaultModeId": "2:0"
-                }
+          }
+        },
+        "900": {
+          "$type": "color",
+          "$value": "#102924",
+          "$description": "Brand Color: Black-Green",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:39:2439",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
               }
             }
           }
@@ -767,7 +879,7 @@
       },
       "shadow": {
         "$type": "color",
-        "$value": "#14141933",
+        "$value": "#14141926",
         "$description": "",
         "$extensions": {
           "mode": {},
@@ -777,6 +889,104 @@
               "id": "VariableCollectionId:2:5",
               "name": "Primitives",
               "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "base": {
+        "whitePrimary": {
+          "$type": "color",
+          "$value": "#ffffff",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:352:1351",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "blackPrimary": {
+          "$type": "color",
+          "$value": "#141419",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:352:1352",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "blackSecondary": {
+          "$type": "color",
+          "$value": "#141419cc",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:393:1065",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "blackTertiary": {
+          "$type": "color",
+          "$value": "#141419a6",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:393:1066",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "whiteSecondary": {
+          "$type": "color",
+          "$value": "#ffffffcc",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:393:1067",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "whiteTertiary": {
+          "$type": "color",
+          "$value": "#ffffffa6",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:393:1068",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
             }
           }
         }
@@ -1548,1776 +1758,26 @@
             }
           }
         }
+      },
+      "hover": {
+        "$type": "dimension",
+        "$value": "10px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:370:918",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
       }
     }
   },
   "Tokens": {
-    "color": {
-      "background": {
-        "surface": {
-          "primary": {
-            "default": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.50}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.50}",
-                  "Dark": "{Primitives.color.neutral.900}"
-                },
-                "figma": {
-                  "variableId": "VariableID:23:57",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "hovered": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.200}",
-                  "Dark": "{Primitives.color.neutral.700}"
-                },
-                "figma": {
-                  "variableId": "VariableID:29:673",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "pressed": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.300}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.300}",
-                  "Dark": "{Primitives.color.neutral.600}"
-                },
-                "figma": {
-                  "variableId": "VariableID:29:674",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "secondary": {
-            "default": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.100}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.100}",
-                  "Dark": "{Primitives.color.neutral.800}"
-                },
-                "figma": {
-                  "variableId": "VariableID:23:58",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "hovered": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.200}",
-                  "Dark": "{Primitives.color.neutral.600}"
-                },
-                "figma": {
-                  "variableId": "VariableID:29:683",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "pressed": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.300}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.300}",
-                  "Dark": "{Primitives.color.neutral.500}"
-                },
-                "figma": {
-                  "variableId": "VariableID:29:684",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "invert": {
-            "default": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.900}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.900}",
-                  "Dark": "{Primitives.color.neutral.50}"
-                },
-                "figma": {
-                  "variableId": "VariableID:23:60",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "hovered": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.800}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.800}",
-                  "Dark": "{Primitives.color.neutral.100}"
-                },
-                "figma": {
-                  "variableId": "VariableID:29:691",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "pressed": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.700}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.700}",
-                  "Dark": "{Primitives.color.neutral.200}"
-                },
-                "figma": {
-                  "variableId": "VariableID:29:692",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "brand": {
-            "default": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.900}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.900}",
-                  "Dark": "{Primitives.color.accent.brand.900}"
-                },
-                "figma": {
-                  "variableId": "VariableID:23:61",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "hovered": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.800}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.800}",
-                  "Dark": "{Primitives.color.accent.brand.800}"
-                },
-                "figma": {
-                  "variableId": "VariableID:29:699",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "pressed": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.700}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.700}",
-                  "Dark": "{Primitives.color.accent.brand.700}"
-                },
-                "figma": {
-                  "variableId": "VariableID:29:700",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "warning": {
-            "default": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.yellow.100}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.yellow.100}",
-                  "Dark": "{Primitives.color.accent.yellow.900}"
-                },
-                "figma": {
-                  "variableId": "VariableID:71:820",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "hovered": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.yellow.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.yellow.200}",
-                  "Dark": "{Primitives.color.accent.yellow.800}"
-                },
-                "figma": {
-                  "variableId": "VariableID:71:821",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "pressed": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.yellow.300}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.yellow.300}",
-                  "Dark": "{Primitives.color.accent.yellow.700}"
-                },
-                "figma": {
-                  "variableId": "VariableID:71:822",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "error": {
-            "default": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.red.100}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.red.100}",
-                  "Dark": "{Primitives.color.accent.red.900}"
-                },
-                "figma": {
-                  "variableId": "VariableID:71:824",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "hovered": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.red.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.red.200}",
-                  "Dark": "{Primitives.color.accent.red.800}"
-                },
-                "figma": {
-                  "variableId": "VariableID:71:825",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "pressed": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.red.300}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.red.300}",
-                  "Dark": "{Primitives.color.accent.red.700}"
-                },
-                "figma": {
-                  "variableId": "VariableID:71:826",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "success": {
-            "default": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.100}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.100}",
-                  "Dark": "{Primitives.color.accent.brand.900}"
-                },
-                "figma": {
-                  "variableId": "VariableID:71:827",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "hovered": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.200}",
-                  "Dark": "{Primitives.color.accent.brand.800}"
-                },
-                "figma": {
-                  "variableId": "VariableID:71:828",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "pressed": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.300}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.300}",
-                  "Dark": "{Primitives.color.accent.brand.700}"
-                },
-                "figma": {
-                  "variableId": "VariableID:71:829",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "tertiary": {
-            "default": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.300}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.300}",
-                  "Dark": "{Primitives.color.neutral.700}"
-                },
-                "figma": {
-                  "variableId": "VariableID:143:1997",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "hovered": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.400}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.400}",
-                  "Dark": "{Primitives.color.neutral.600}"
-                },
-                "figma": {
-                  "variableId": "VariableID:143:1998",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "pressed": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.500}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.500}",
-                  "Dark": "{Primitives.color.neutral.500}"
-                },
-                "figma": {
-                  "variableId": "VariableID:143:1999",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "button": {
-          "primary": {
-            "onLight": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.900}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.900}",
-                    "Dark": "{Primitives.color.accent.brand.300}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:29:665",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.800}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.800}",
-                    "Dark": "{Primitives.color.accent.brand.400}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:29:669",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.700}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.700}",
-                    "Dark": "{Primitives.color.accent.brand.500}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:29:670",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            },
-            "onDark": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.300}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.300}",
-                    "Dark": "{Primitives.color.accent.brand.700}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:78:1205",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.400}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.400}",
-                    "Dark": "{Primitives.color.accent.brand.600}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:78:1206",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.500}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.500}",
-                    "Dark": "{Primitives.color.accent.brand.500}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:78:1207",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "secondary": {
-            "onLight": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.neutral.50}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.neutral.50}",
-                    "Dark": "{Primitives.color.neutral.50}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:78:1408",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.100}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.100}",
-                    "Dark": "{Primitives.color.accent.brand.600}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:78:1409",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.200}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.200}",
-                    "Dark": "{Primitives.color.accent.brand.500}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:78:1410",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            },
-            "onDark": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.700}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.700}",
-                    "Dark": "{Primitives.color.accent.brand.700}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:78:1411",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.600}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.600}",
-                    "Dark": "{Primitives.color.accent.brand.600}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:78:1412",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.500}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.500}",
-                    "Dark": "{Primitives.color.accent.brand.500}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:78:1413",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "tertiary": {
-            "onLight": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.neutral.50}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.neutral.50}",
-                    "Dark": "{Primitives.color.neutral.50}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1846",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.100}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.100}",
-                    "Dark": "{Primitives.color.accent.brand.100}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1847",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.200}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.200}",
-                    "Dark": "{Primitives.color.accent.brand.200}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1848",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            },
-            "onDark": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.neutral.50}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.neutral.50}",
-                    "Dark": "{Primitives.color.neutral.50}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1849",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.green.800}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.green.800}",
-                    "Dark": "{Primitives.color.accent.brand.100}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1850",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.green.700}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.green.700}",
-                    "Dark": "{Primitives.color.accent.brand.200}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1851",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "brand": {
-            "onLight": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.900}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.900}",
-                    "Dark": "{Primitives.color.accent.brand.300}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1852",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.800}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.800}",
-                    "Dark": "{Primitives.color.accent.brand.400}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1853",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.700}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.700}",
-                    "Dark": "{Primitives.color.accent.brand.500}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1854",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            },
-            "onDark": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.300}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.300}",
-                    "Dark": "{Primitives.color.accent.brand.900}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1855",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.400}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.400}",
-                    "Dark": "{Primitives.color.accent.brand.800}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1856",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.brand.500}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.brand.500}",
-                    "Dark": "{Primitives.color.accent.brand.600}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1857",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "destructive": {
-            "onLight": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.red.600}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.red.600}",
-                    "Dark": "{Primitives.color.accent.red.600}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1858",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.red.500}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.red.500}",
-                    "Dark": "{Primitives.color.accent.red.500}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1859",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.red.400}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.red.400}",
-                    "Dark": "{Primitives.color.accent.red.400}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1860",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            },
-            "onDark": {
-              "default": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.red.200}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.red.200}",
-                    "Dark": "{Primitives.color.accent.red.600}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1861",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "hovered": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.red.300}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.red.300}",
-                    "Dark": "{Primitives.color.accent.red.500}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1862",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              },
-              "pressed": {
-                "$type": "color",
-                "$value": "{Primitives.color.accent.red.400}",
-                "$description": "",
-                "$extensions": {
-                  "mode": {
-                    "Light": "{Primitives.color.accent.red.400}",
-                    "Dark": "{Primitives.color.accent.red.400}"
-                  },
-                  "figma": {
-                    "variableId": "VariableID:83:1863",
-                    "collection": {
-                      "id": "VariableCollectionId:23:56",
-                      "name": "Tokens",
-                      "defaultModeId": "23:0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "textfield": {
-          "default": {
-            "$type": "color",
-            "$value": "{Primitives.color.neutral.50}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.neutral.50}",
-                "Dark": "{Primitives.color.neutral.800}"
-              },
-              "figma": {
-                "variableId": "VariableID:131:1678",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          }
-        },
-        "badge": {
-          "positive": {
-            "dark": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.900}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.900}",
-                  "Dark": "{Primitives.color.accent.brand.200}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3774",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "light": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.200}",
-                  "Dark": "{Primitives.color.accent.brand.900}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3775",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "caution": {
-            "dark": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.yellow.900}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.yellow.900}",
-                  "Dark": "{Primitives.color.accent.yellow.200}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3805",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "light": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.yellow.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.yellow.200}",
-                  "Dark": "{Primitives.color.accent.yellow.900}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3806",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "critical": {
-            "dark": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.red.700}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.red.700}",
-                  "Dark": "{Primitives.color.accent.red.200}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3821",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "light": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.red.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.red.200}",
-                  "Dark": "{Primitives.color.accent.red.700}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3822",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "neutral": {
-            "dark": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.800}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.800}",
-                  "Dark": "{Primitives.color.neutral.200}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3838",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "light": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.200}",
-                  "Dark": "{Primitives.color.neutral.800}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3839",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "text": {
-        "primary": {
-          "onLight": {
-            "$type": "color",
-            "$value": "{Primitives.color.neutral.800}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.neutral.800}",
-                "Dark": "{Primitives.color.neutral.100}"
-              },
-              "figma": {
-                "variableId": "VariableID:23:72",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          },
-          "onDark": {
-            "$type": "color",
-            "$value": "{Primitives.color.neutral.100}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.neutral.100}",
-                "Dark": "{Primitives.color.neutral.800}"
-              },
-              "figma": {
-                "variableId": "VariableID:78:159",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          }
-        },
-        "secondary": {
-          "onLight": {
-            "$type": "color",
-            "$value": "{Primitives.color.neutral.700}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.neutral.700}",
-                "Dark": "{Primitives.color.neutral.200}"
-              },
-              "figma": {
-                "variableId": "VariableID:23:73",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          },
-          "onDark": {
-            "$type": "color",
-            "$value": "{Primitives.color.neutral.200}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.neutral.200}",
-                "Dark": "{Primitives.color.neutral.700}"
-              },
-              "figma": {
-                "variableId": "VariableID:78:160",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          }
-        },
-        "brand": {
-          "onLight": {
-            "$type": "color",
-            "$value": "{Primitives.color.accent.brand.900}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.accent.brand.900}",
-                "Dark": "{Primitives.color.accent.brand.300}"
-              },
-              "figma": {
-                "variableId": "VariableID:23:74",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          },
-          "onDark": {
-            "$type": "color",
-            "$value": "{Primitives.color.accent.brand.300}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.accent.brand.300}",
-                "Dark": "{Primitives.color.accent.brand.900}"
-              },
-              "figma": {
-                "variableId": "VariableID:78:161",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          }
-        },
-        "warning": {
-          "onLight": {
-            "$type": "color",
-            "$value": "{Primitives.color.accent.yellow.900}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.accent.yellow.900}",
-                "Dark": "{Primitives.color.accent.yellow.100}"
-              },
-              "figma": {
-                "variableId": "VariableID:39:2434",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          },
-          "onDark": {
-            "$type": "color",
-            "$value": "{Primitives.color.accent.yellow.100}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.accent.yellow.100}",
-                "Dark": "{Primitives.color.accent.yellow.100}"
-              },
-              "figma": {
-                "variableId": "VariableID:71:850",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          }
-        },
-        "error": {
-          "onLight": {
-            "$type": "color",
-            "$value": "{Primitives.color.accent.red.700}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.accent.red.700}",
-                "Dark": "{Primitives.color.accent.red.100}"
-              },
-              "figma": {
-                "variableId": "VariableID:71:830",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          },
-          "onDark": {
-            "$type": "color",
-            "$value": "{Primitives.color.accent.red.100}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.accent.red.100}",
-                "Dark": "{Primitives.color.accent.red.100}"
-              },
-              "figma": {
-                "variableId": "VariableID:71:851",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          }
-        },
-        "success": {
-          "onLight": {
-            "$type": "color",
-            "$value": "{Primitives.color.accent.brand.900}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.accent.brand.900}",
-                "Dark": "{Primitives.color.accent.brand.100}"
-              },
-              "figma": {
-                "variableId": "VariableID:71:831",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          },
-          "onDqark": {
-            "$type": "color",
-            "$value": "{Primitives.color.accent.brand.100}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.accent.brand.100}",
-                "Dark": "{Primitives.color.accent.brand.100}"
-              },
-              "figma": {
-                "variableId": "VariableID:131:1699",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          }
-        },
-        "tertiary": {
-          "onLight": {
-            "$type": "color",
-            "$value": "{Primitives.color.neutral.700}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.neutral.700}",
-                "Dark": "{Primitives.color.neutral.200}"
-              },
-              "figma": {
-                "variableId": "VariableID:78:162",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          },
-          "onDark": {
-            "$type": "color",
-            "$value": "{Primitives.color.neutral.200}",
-            "$description": "",
-            "$extensions": {
-              "mode": {
-                "Light": "{Primitives.color.neutral.200}",
-                "Dark": "{Primitives.color.neutral.700}"
-              },
-              "figma": {
-                "variableId": "VariableID:78:163",
-                "collection": {
-                  "id": "VariableCollectionId:23:56",
-                  "name": "Tokens",
-                  "defaultModeId": "23:0"
-                }
-              }
-            }
-          }
-        },
-        "badge": {
-          "positive": {
-            "dark": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.900}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.900}",
-                  "Dark": "{Primitives.color.accent.brand.200}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3776",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "light": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.brand.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.brand.200}",
-                  "Dark": "{Primitives.color.accent.brand.900}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3777",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "caution": {
-            "dark": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.yellow.900}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.yellow.900}",
-                  "Dark": "{Primitives.color.accent.yellow.200}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3807",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "light": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.yellow.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.yellow.200}",
-                  "Dark": "{Primitives.color.accent.yellow.900}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3808",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "critical": {
-            "dark": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.red.700}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.red.700}",
-                  "Dark": "{Primitives.color.accent.red.200}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3823",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "light": {
-              "$type": "color",
-              "$value": "{Primitives.color.accent.red.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.accent.red.200}",
-                  "Dark": "{Primitives.color.accent.red.700}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3824",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          },
-          "neutral": {
-            "dark": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.800}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.800}",
-                  "Dark": "{Primitives.color.neutral.200}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3840",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            },
-            "light": {
-              "$type": "color",
-              "$value": "{Primitives.color.neutral.200}",
-              "$description": "",
-              "$extensions": {
-                "mode": {
-                  "Light": "{Primitives.color.neutral.200}",
-                  "Dark": "{Primitives.color.neutral.800}"
-                },
-                "figma": {
-                  "variableId": "VariableID:144:3841",
-                  "collection": {
-                    "id": "VariableCollectionId:23:56",
-                    "name": "Tokens",
-                    "defaultModeId": "23:0"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "link": {
-        "default": {
-          "$type": "color",
-          "$value": "{Primitives.color.green.900}",
-          "$description": "",
-          "$extensions": {
-            "mode": {
-              "Light": "{Primitives.color.green.900}",
-              "Dark": "{Primitives.color.green.100}"
-            },
-            "figma": {
-              "variableId": "VariableID:29:703",
-              "collection": {
-                "id": "VariableCollectionId:23:56",
-                "name": "Tokens",
-                "defaultModeId": "23:0"
-              }
-            }
-          }
-        },
-        "hovered": {
-          "$type": "color",
-          "$value": "{Primitives.color.green.800}",
-          "$description": "",
-          "$extensions": {
-            "mode": {
-              "Light": "{Primitives.color.green.800}",
-              "Dark": "{Primitives.color.green.200}"
-            },
-            "figma": {
-              "variableId": "VariableID:71:832",
-              "collection": {
-                "id": "VariableCollectionId:23:56",
-                "name": "Tokens",
-                "defaultModeId": "23:0"
-              }
-            }
-          }
-        },
-        "pressed": {
-          "$type": "color",
-          "$value": "{Primitives.color.green.700}",
-          "$description": "",
-          "$extensions": {
-            "mode": {
-              "Light": "{Primitives.color.green.700}",
-              "Dark": "{Primitives.color.green.300}"
-            },
-            "figma": {
-              "variableId": "VariableID:71:833",
-              "collection": {
-                "id": "VariableCollectionId:23:56",
-                "name": "Tokens",
-                "defaultModeId": "23:0"
-              }
-            }
-          }
-        }
-      }
-    },
     "spacing": {
       "none": {
         "$type": "dimension",
@@ -3433,7 +1893,7 @@
           }
         }
       },
-      "spacing-2xl": {
+      "2xl": {
         "$type": "dimension",
         "$value": "{Primitives.spacing.10}",
         "$description": "",
@@ -3529,18 +1989,1877 @@
             }
           }
         }
+      },
+      "rounded large": {
+        "$type": "dimension",
+        "$value": "{Primitives.radius.lg}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.radius.lg}",
+            "Dark": "{Primitives.radius.lg}"
+          },
+          "figma": {
+            "variableId": "VariableID:349:1170",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      }
+    },
+    "color": {
+      "text": {
+        "primary": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.blackPrimary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.blackPrimary}",
+                "Dark": "{Primitives.color.base.whitePrimary}"
+              },
+              "figma": {
+                "variableId": "VariableID:23:72",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.whitePrimary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.whitePrimary}",
+                "Dark": "{Primitives.color.base.blackPrimary}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:159",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "darkOnly": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.blackPrimary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.blackPrimary}",
+                "Dark": "{Primitives.color.base.blackPrimary}"
+              },
+              "figma": {
+                "variableId": "VariableID:386:1106",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "secondary": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.blackSecondary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.blackSecondary}",
+                "Dark": "{Primitives.color.base.whiteSecondary}"
+              },
+              "figma": {
+                "variableId": "VariableID:23:73",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.whiteSecondary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.whiteSecondary}",
+                "Dark": "{Primitives.color.base.blackSecondary}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:160",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "darkOnly": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.blackSecondary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.blackSecondary}",
+                "Dark": "{Primitives.color.base.blackSecondary}"
+              },
+              "figma": {
+                "variableId": "VariableID:386:1107",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "brand": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.900}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.900}",
+                "Dark": "{Primitives.color.brand.300}"
+              },
+              "figma": {
+                "variableId": "VariableID:23:74",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.300}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.300}",
+                "Dark": "{Primitives.color.brand.900}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:161",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "lightOnly": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.300}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.300}",
+                "Dark": "{Primitives.color.brand.300}"
+              },
+              "figma": {
+                "variableId": "VariableID:385:1104",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "darkOnly": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.900}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.900}",
+                "Dark": "{Primitives.color.brand.900}"
+              },
+              "figma": {
+                "variableId": "VariableID:385:1105",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "warning": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.yellow.900}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.yellow.900}",
+                "Dark": "{Primitives.color.feedback.yellow.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:39:2434",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.yellow.100}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.yellow.100}",
+                "Dark": "{Primitives.color.feedback.yellow.900}"
+              },
+              "figma": {
+                "variableId": "VariableID:71:850",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "error": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.red.800}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.red.800}",
+                "Dark": "{Primitives.color.feedback.red.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:71:830",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.red.100}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.red.100}",
+                "Dark": "{Primitives.color.feedback.red.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:71:851",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "success": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.green.900}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.green.900}",
+                "Dark": "{Primitives.color.feedback.green.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:71:831",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDqark": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.green.200}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.green.200}",
+                "Dark": "{Primitives.color.feedback.green.900}"
+              },
+              "figma": {
+                "variableId": "VariableID:131:1699",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "tertiary": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.blackTertiary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.blackTertiary}",
+                "Dark": "{Primitives.color.base.whiteTertiary}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:162",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.whiteTertiary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.whiteTertiary}",
+                "Dark": "{Primitives.color.base.blackTertiary}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:163",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "darkOnly": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.blackTertiary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.blackTertiary}",
+                "Dark": "{Primitives.color.base.blackTertiary}"
+              },
+              "figma": {
+                "variableId": "VariableID:386:1108",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "button": {
+        "primary": {
+          "onLight": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.900}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.900}",
+                  "Dark": "{Primitives.color.brand.300}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:665",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.800}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.800}",
+                  "Dark": "{Primitives.color.brand.400}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:669",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.700}",
+                  "Dark": "{Primitives.color.brand.500}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:670",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "onDark": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.300}",
+                  "Dark": "{Primitives.color.brand.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:78:1205",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.400}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.400}",
+                  "Dark": "{Primitives.color.brand.600}"
+                },
+                "figma": {
+                  "variableId": "VariableID:78:1206",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.500}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.500}",
+                  "Dark": "{Primitives.color.brand.500}"
+                },
+                "figma": {
+                  "variableId": "VariableID:78:1207",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "secondary": {
+          "onLight": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.50}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.50}",
+                  "Dark": "{Primitives.color.brand.50}"
+                },
+                "figma": {
+                  "variableId": "VariableID:78:1408",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.200}",
+                  "Dark": "{Primitives.color.brand.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:78:1409",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.300}",
+                  "Dark": "{Primitives.color.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:78:1410",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "onDark": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.700}",
+                  "Dark": "{Primitives.color.brand.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:78:1411",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.800}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.800}",
+                  "Dark": "{Primitives.color.brand.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:78:1412",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.700}",
+                  "Dark": "{Primitives.color.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:78:1413",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tertiary": {
+          "onLight": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.50}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.50}",
+                  "Dark": "{Primitives.color.brand.50}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1846",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.200}",
+                  "Dark": "{Primitives.color.brand.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1847",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.300}",
+                  "Dark": "{Primitives.color.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1848",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "onDark": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.50}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.50}",
+                  "Dark": "{Primitives.color.brand.50}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1849",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.800}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.800}",
+                  "Dark": "{Primitives.color.brand.100}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1850",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.700}",
+                  "Dark": "{Primitives.color.brand.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1851",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "destructive": {
+          "onLight": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.feedback.red.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.feedback.red.700}",
+                  "Dark": "{Primitives.color.feedback.red.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1858",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.feedback.red.600}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.feedback.red.600}",
+                  "Dark": "{Primitives.color.feedback.red.600}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1859",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.feedback.red.500}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.feedback.red.500}",
+                  "Dark": "{Primitives.color.feedback.red.500}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1860",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "onDark": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.feedback.red.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.feedback.red.700}",
+                  "Dark": "{Primitives.color.feedback.red.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1861",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.feedback.red.600}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.feedback.red.600}",
+                  "Dark": "{Primitives.color.feedback.red.600}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1862",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.feedback.red.500}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.feedback.red.500}",
+                  "Dark": "{Primitives.color.feedback.red.500}"
+                },
+                "figma": {
+                  "variableId": "VariableID:83:1863",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "link": {
+        "default": {
+          "$type": "color",
+          "$value": "{Primitives.color.brand.700}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.brand.700}",
+              "Dark": "{Primitives.color.brand.500}"
+            },
+            "figma": {
+              "variableId": "VariableID:29:703",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "hovered": {
+          "$type": "color",
+          "$value": "{Primitives.color.brand.600}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.brand.600}",
+              "Dark": "{Primitives.color.feedback.green.400}"
+            },
+            "figma": {
+              "variableId": "VariableID:71:832",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{Primitives.color.brand.500}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.brand.500}",
+              "Dark": "{Primitives.color.feedback.green.300}"
+            },
+            "figma": {
+              "variableId": "VariableID:71:833",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "feedback": {
+        "positive": {
+          "dark": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.green.950}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.green.950}",
+                "Dark": "{Primitives.color.feedback.green.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:144:3774",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "light": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.green.200}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.green.200}",
+                "Dark": "{Primitives.color.feedback.green.950}"
+              },
+              "figma": {
+                "variableId": "VariableID:144:3775",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "caution": {
+          "dark": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.yellow.900}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.yellow.900}",
+                "Dark": "{Primitives.color.feedback.yellow.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:144:3805",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "light": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.yellow.200}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.yellow.200}",
+                "Dark": "{Primitives.color.feedback.yellow.900}"
+              },
+              "figma": {
+                "variableId": "VariableID:144:3806",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "critical": {
+          "dark": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.red.700}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.red.700}",
+                "Dark": "{Primitives.color.feedback.red.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:144:3821",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "light": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.red.200}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.red.200}",
+                "Dark": "{Primitives.color.feedback.red.700}"
+              },
+              "figma": {
+                "variableId": "VariableID:144:3822",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "neutral": {
+          "dark": {
+            "$type": "color",
+            "$value": "{Primitives.color.neutral.800}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.neutral.800}",
+                "Dark": "{Primitives.color.neutral.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:144:3838",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "light": {
+            "$type": "color",
+            "$value": "{Primitives.color.neutral.200}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.neutral.200}",
+                "Dark": "{Primitives.color.neutral.800}"
+              },
+              "figma": {
+                "variableId": "VariableID:144:3839",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "new": {
+          "dark": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.800}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.800}",
+                "Dark": "{Primitives.color.brand.300}"
+              },
+              "figma": {
+                "variableId": "VariableID:393:825",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "light": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.300}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.300}",
+                "Dark": "{Primitives.color.brand.800}"
+              },
+              "figma": {
+                "variableId": "VariableID:393:826",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "icon": {
+        "primary": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.blackSecondary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.blackSecondary}",
+                "Dark": "{Primitives.color.base.whiteSecondary}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:893",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.whiteSecondary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.whiteSecondary}",
+                "Dark": "{Primitives.color.base.blackSecondary}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:894",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "secondary": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.blackTertiary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.blackTertiary}",
+                "Dark": "{Primitives.color.base.whiteTertiary}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:895",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.whiteTertiary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.whiteTertiary}",
+                "Dark": "{Primitives.color.base.blackTertiary}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:896",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "tertiary": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.blackTertiary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.blackTertiary}",
+                "Dark": "{Primitives.color.base.whiteTertiary}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:897",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.base.whiteTertiary}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.base.whiteTertiary}",
+                "Dark": "{Primitives.color.base.blackTertiary}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:898",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "brand": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.800}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.800}",
+                "Dark": "{Primitives.color.brand.400}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:899",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.400}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.400}",
+                "Dark": "{Primitives.color.brand.800}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:900",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "warning": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.yellow.800}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.yellow.800}",
+                "Dark": "{Primitives.color.feedback.yellow.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:901",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.yellow.200}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.yellow.200}",
+                "Dark": "{Primitives.color.feedback.yellow.800}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:902",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "error": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.red.700}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.red.700}",
+                "Dark": "{Primitives.color.feedback.red.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:903",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.red.200}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.red.200}",
+                "Dark": "{Primitives.color.feedback.red.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:904",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "success": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.green.800}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.green.800}",
+                "Dark": "{Primitives.color.feedback.green.300}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:905",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDqark": {
+            "$type": "color",
+            "$value": "{Primitives.color.feedback.green.300}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.feedback.green.300}",
+                "Dark": "{Primitives.color.feedback.green.800}"
+              },
+              "figma": {
+                "variableId": "VariableID:330:908",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "new": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.700}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.700}",
+                "Dark": "{Primitives.color.brand.300}"
+              },
+              "figma": {
+                "variableId": "VariableID:394:1049",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.brand.300}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.brand.300}",
+                "Dark": "{Primitives.color.brand.700}"
+              },
+              "figma": {
+                "variableId": "VariableID:394:1050",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "background": {
+        "neutral": {
+          "$type": "color",
+          "$value": "{Primitives.color.neutral.50}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.neutral.50}",
+              "Dark": "{Primitives.color.brand.800}"
+            },
+            "figma": {
+              "variableId": "VariableID:390:939",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "brand 1": {
+          "$type": "color",
+          "$value": "{Primitives.color.brand.300}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.brand.300}",
+              "Dark": "{Primitives.color.brand.800}"
+            },
+            "figma": {
+              "variableId": "VariableID:390:966",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "fill": {
+          "inverted": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.base.whitePrimary}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.base.whitePrimary}",
+                  "Dark": "{Primitives.color.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:977",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.100}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.100}",
+                  "Dark": "{Primitives.color.brand.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:980",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.200}",
+                  "Dark": "{Primitives.color.brand.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:981",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "brand": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.300}",
+                  "Dark": "{Primitives.color.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:982",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.400}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.400}",
+                  "Dark": "{Primitives.color.brand.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:983",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.500}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.500}",
+                  "Dark": "{Primitives.color.brand.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:984",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "recessed": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.100}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.100}",
+                  "Dark": "{Primitives.color.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:985",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.200}",
+                  "Dark": "{Primitives.color.brand.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:986",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.300}",
+                  "Dark": "{Primitives.color.brand.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:987",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "dark": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.900}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.900}",
+                  "Dark": "{Primitives.color.brand.50}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:988",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.800}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.800}",
+                  "Dark": "{Primitives.color.brand.100}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:989",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.700}",
+                  "Dark": "{Primitives.color.brand.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:990",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "darkOnly": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.900}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.900}",
+                  "Dark": "{Primitives.color.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:991",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.800}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.800}",
+                  "Dark": "{Primitives.color.brand.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:992",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.700}",
+                  "Dark": "{Primitives.color.brand.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:993",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "state": {
+            "on": {
+              "$type": "color",
+              "$value": "{Primitives.color.brand.500}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.brand.500}",
+                  "Dark": "{Primitives.color.brand.500}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:1233",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "off": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.400}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.400}",
+                  "Dark": "{Primitives.color.neutral.400}"
+                },
+                "figma": {
+                  "variableId": "VariableID:390:1234",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "brand 2": {
+          "$type": "color",
+          "$value": "{Primitives.color.neutral.200}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.neutral.200}",
+              "Dark": "{Primitives.color.brand.800}"
+            },
+            "figma": {
+              "variableId": "VariableID:391:781",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
       }
     },
     "border": {
       "primary": {
         "onLight": {
           "$type": "color",
-          "$value": "{Primitives.color.green.900}",
+          "$value": "{Primitives.color.neutral.700}",
           "$description": "",
           "$extensions": {
             "mode": {
-              "Light": "{Primitives.color.green.900}",
-              "Dark": "{Primitives.color.green.600}"
+              "Light": "{Primitives.color.neutral.700}",
+              "Dark": "{Primitives.color.brand.300}"
             },
             "figma": {
               "variableId": "VariableID:23:76",
@@ -3554,12 +3873,12 @@
         },
         "onDark": {
           "$type": "color",
-          "$value": "{Primitives.color.green.600}",
+          "$value": "{Primitives.color.neutral.500}",
           "$description": "",
           "$extensions": {
             "mode": {
-              "Light": "{Primitives.color.green.600}",
-              "Dark": "{Primitives.color.accent.brand.900}"
+              "Light": "{Primitives.color.neutral.500}",
+              "Dark": "{Primitives.color.brand.300}"
             },
             "figma": {
               "variableId": "VariableID:78:1414",
@@ -3575,95 +3894,15 @@
       "secondary": {
         "onLight": {
           "$type": "color",
-          "$value": "{Primitives.color.green.600}",
+          "$value": "{Primitives.color.neutral.500}",
           "$description": "",
           "$extensions": {
             "mode": {
-              "Light": "{Primitives.color.green.600}",
-              "Dark": "{Primitives.color.green.400}"
+              "Light": "{Primitives.color.neutral.500}",
+              "Dark": "{Primitives.color.brand.700}"
             },
             "figma": {
               "variableId": "VariableID:23:77",
-              "collection": {
-                "id": "VariableCollectionId:23:56",
-                "name": "Tokens",
-                "defaultModeId": "23:0"
-              }
-            }
-          }
-        },
-        "onDark": {
-          "$type": "color",
-          "$value": "{Primitives.color.green.400}",
-          "$description": "",
-          "$extensions": {
-            "mode": {
-              "Light": "{Primitives.color.green.400}",
-              "Dark": "{Primitives.color.green.600}"
-            },
-            "figma": {
-              "variableId": "VariableID:78:1415",
-              "collection": {
-                "id": "VariableCollectionId:23:56",
-                "name": "Tokens",
-                "defaultModeId": "23:0"
-              }
-            }
-          }
-        }
-      },
-      "focused": {
-        "onLight": {
-          "$type": "color",
-          "$value": "{Primitives.color.accent.brand.500}",
-          "$description": "",
-          "$extensions": {
-            "mode": {
-              "Light": "{Primitives.color.accent.brand.500}",
-              "Dark": "{Primitives.color.accent.brand.500}"
-            },
-            "figma": {
-              "variableId": "VariableID:38:353",
-              "collection": {
-                "id": "VariableCollectionId:23:56",
-                "name": "Tokens",
-                "defaultModeId": "23:0"
-              }
-            }
-          }
-        },
-        "onDark": {
-          "$type": "color",
-          "$value": "{Primitives.color.accent.brand.500}",
-          "$description": "",
-          "$extensions": {
-            "mode": {
-              "Light": "{Primitives.color.accent.brand.500}",
-              "Dark": "{Primitives.color.accent.brand.500}"
-            },
-            "figma": {
-              "variableId": "VariableID:171:597",
-              "collection": {
-                "id": "VariableCollectionId:23:56",
-                "name": "Tokens",
-                "defaultModeId": "23:0"
-              }
-            }
-          }
-        }
-      },
-      "tertiary": {
-        "onLight": {
-          "$type": "color",
-          "$value": "{Primitives.color.neutral.200}",
-          "$description": "",
-          "$extensions": {
-            "mode": {
-              "Light": "{Primitives.color.neutral.200}",
-              "Dark": "{Primitives.color.neutral.700}"
-            },
-            "figma": {
-              "variableId": "VariableID:108:485",
               "collection": {
                 "id": "VariableCollectionId:23:56",
                 "name": "Tokens",
@@ -3679,7 +3918,87 @@
           "$extensions": {
             "mode": {
               "Light": "{Primitives.color.neutral.700}",
-              "Dark": "{Primitives.color.neutral.700}"
+              "Dark": "{Primitives.color.brand.700}"
+            },
+            "figma": {
+              "variableId": "VariableID:78:1415",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "focused": {
+        "onLight": {
+          "$type": "color",
+          "$value": "{Primitives.color.brand.500}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.brand.500}",
+              "Dark": "{Primitives.color.brand.500}"
+            },
+            "figma": {
+              "variableId": "VariableID:38:353",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "onDark": {
+          "$type": "color",
+          "$value": "{Primitives.color.brand.500}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.brand.500}",
+              "Dark": "{Primitives.color.brand.500}"
+            },
+            "figma": {
+              "variableId": "VariableID:171:597",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "onLight": {
+          "$type": "color",
+          "$value": "{Primitives.color.base.whitePrimary}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.base.whitePrimary}",
+              "Dark": "{Primitives.color.brand.900}"
+            },
+            "figma": {
+              "variableId": "VariableID:108:485",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "onDark": {
+          "$type": "color",
+          "$value": "{Primitives.color.brand.900}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.brand.900}",
+              "Dark": "{Primitives.color.base.whitePrimary}"
             },
             "figma": {
               "variableId": "VariableID:108:486",
@@ -3695,12 +4014,12 @@
       "error": {
         "onLight": {
           "$type": "color",
-          "$value": "{Primitives.color.accent.red.700}",
+          "$value": "{Primitives.color.feedback.red.700}",
           "$description": "",
           "$extensions": {
             "mode": {
-              "Light": "{Primitives.color.accent.red.700}",
-              "Dark": "{Primitives.color.accent.red.300}"
+              "Light": "{Primitives.color.feedback.red.700}",
+              "Dark": "{Primitives.color.feedback.red.200}"
             },
             "figma": {
               "variableId": "VariableID:127:1004",
@@ -3714,55 +4033,15 @@
         },
         "onDark": {
           "$type": "color",
-          "$value": "{Primitives.color.accent.red.300}",
+          "$value": "{Primitives.color.feedback.red.200}",
           "$description": "",
           "$extensions": {
             "mode": {
-              "Light": "{Primitives.color.accent.red.300}",
-              "Dark": "{Primitives.color.accent.red.300}"
+              "Light": "{Primitives.color.feedback.red.200}",
+              "Dark": "{Primitives.color.feedback.red.700}"
             },
             "figma": {
               "variableId": "VariableID:127:1005",
-              "collection": {
-                "id": "VariableCollectionId:23:56",
-                "name": "Tokens",
-                "defaultModeId": "23:0"
-              }
-            }
-          }
-        }
-      },
-      "brand": {
-        "onLight": {
-          "$type": "color",
-          "$value": "{Primitives.color.accent.brand.500}",
-          "$description": "",
-          "$extensions": {
-            "mode": {
-              "Light": "{Primitives.color.accent.brand.500}",
-              "Dark": "{Primitives.color.accent.brand.500}"
-            },
-            "figma": {
-              "variableId": "VariableID:131:1675",
-              "collection": {
-                "id": "VariableCollectionId:23:56",
-                "name": "Tokens",
-                "defaultModeId": "23:0"
-              }
-            }
-          }
-        },
-        "onDark": {
-          "$type": "color",
-          "$value": "{Primitives.color.accent.brand.300}",
-          "$description": "",
-          "$extensions": {
-            "mode": {
-              "Light": "{Primitives.color.accent.brand.300}",
-              "Dark": "{Primitives.color.accent.brand.300}"
-            },
-            "figma": {
-              "variableId": "VariableID:131:1676",
               "collection": {
                 "id": "VariableCollectionId:23:56",
                 "name": "Tokens",
@@ -4182,12 +4461,12 @@
         },
         "body-regular-multiline": {
           "$type": "dimension",
-          "$value": "{Primitives.line-height.s}",
+          "$value": "{Primitives.line-height.md}",
           "$description": "",
           "$extensions": {
             "mode": {
-              "Light": "{Primitives.line-height.s}",
-              "Dark": "{Primitives.line-height.s}"
+              "Light": "{Primitives.line-height.md}",
+              "Dark": "{Primitives.line-height.md}"
             },
             "figma": {
               "variableId": "VariableID:25:51",
@@ -4431,6 +4710,25 @@
             }
           }
         }
+      },
+      "hover": {
+        "$type": "dimension",
+        "$value": "{Primitives.opacity.hover}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.opacity.hover}",
+            "Dark": "{Primitives.opacity.hover}"
+          },
+          "figma": {
+            "variableId": "VariableID:370:919",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
       }
     },
     "shadow": {
@@ -4511,6 +4809,84 @@
             }
           }
         }
+      },
+      "second level": {
+        "color": {
+          "$type": "color",
+          "$value": "{Primitives.color.shadow}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.shadow}",
+              "Dark": "{Primitives.color.shadow}"
+            },
+            "figma": {
+              "variableId": "VariableID:382:942",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "x": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "0px",
+              "Dark": "0px"
+            },
+            "figma": {
+              "variableId": "VariableID:382:943",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "y": {
+          "$type": "dimension",
+          "$value": "4px",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "4px",
+              "Dark": "4px"
+            },
+            "figma": {
+              "variableId": "VariableID:382:944",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "blur": {
+          "$type": "dimension",
+          "$value": "8px",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "8px",
+              "Dark": "8px"
+            },
+            "figma": {
+              "variableId": "VariableID:382:945",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -4519,7 +4895,7 @@
       "useDTCGKeys": true,
       "colorMode": "hex",
       "variableCollections": ["Primitives", "Tokens"],
-      "createdAt": "2024-10-18T12:52:37.979Z"
+      "createdAt": "2024-11-08T07:35:03.775Z"
     }
   }
 }

--- a/packages/foundation/atomic-playfulness.tokens.json
+++ b/packages/foundation/atomic-playfulness.tokens.json
@@ -1,159 +1,4525 @@
 {
-  "space": {
-    "$type": "dimension",
-    "$description": "Space scale to be used for white-space.",
-
-    "none": { "$value": "0rem" },
-    "3xs": { "$value": "0.125rem" },
-    "2xs": { "$value": "0.25rem" },
-    "xs": { "$value": "0.5rem" },
-    "s": { "$value": "0.75rem" },
-    "m": { "$value": "1rem" },
-    "l": { "$value": "1.5rem" },
-    "xl": { "$value": "2rem" },
-    "2xl": { "$value": "3rem" },
-    "3xl": { "$value": "4rem" }
-  },
-  "font": {
-    "family": {
-      "$type": "fontFamily",
-
-      "kurrent": {
-        "$value": ["ES Klarheit Kurrent RD", "Helvetica", "Arial", "sans-serif"]
+  "Primitives": {
+    "color": {
+      "green": {
+        "100": {
+          "$type": "color",
+          "$value": "#d6f2e5",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:39:2433",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "200": {
+          "$type": "color",
+          "$value": "#98d2b7",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:39:2431",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": "#549a79",
+          "$description": "Brand Color: Forest Green B4",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:2:8",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": "#478467",
+          "$description": "Brand Color: Forest Green B3",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:2:11",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": "#396d55",
+          "$description": "Brand Color: Forest Green B2",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:2:9",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": "#285340",
+          "$description": "Brand Color: Forest Green B1",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:2:10",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": "#1e4132",
+          "$description": "Brand Color: Forest Green",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:2:7",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": "#10352a",
+          "$description": "Brand Color: Forest Green D1",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:21:98",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "900": {
+          "$type": "color",
+          "$value": "#102928",
+          "$description": "Brand Color: Black-Green",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:39:2432",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        }
       },
-      "grotesk": {
-        "$value": ["ES Klarheit Grotesk RD", "Helvetica", "Arial", "sans-serif"]
+      "neutral": {
+        "50": {
+          "$type": "color",
+          "$value": "#ffffff",
+          "$description": "Brand Color: White",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:28:655",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "100": {
+          "$type": "color",
+          "$value": "#f0f8ff",
+          "$description": "Brand Color: Blue-Grey B2",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:2:13",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "200": {
+          "$type": "color",
+          "$value": "#dce4fb",
+          "$description": "Brand Color: Blue-Grey B1",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:2:15",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "300": {
+          "$type": "color",
+          "$value": "#c7cfeb",
+          "$description": "Brand Color: Blue-Grey",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:23:59",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "400": {
+          "$type": "color",
+          "$value": "#b3bcd3",
+          "$description": "Brand Color: Blue-Grey D1",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:21:93",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "500": {
+          "$type": "color",
+          "$value": "#9ca4b8",
+          "$description": "Brand Color: Blue-Grey D2",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:21:94",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "600": {
+          "$type": "color",
+          "$value": "#9ca4b8",
+          "$description": "Brand Color: Blue-Grey D2",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:183:689",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "700": {
+          "$type": "color",
+          "$value": "#4c5979",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:21:96",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "800": {
+          "$type": "color",
+          "$value": "#283c5a",
+          "$description": "Brand Color: Dark Blue",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:21:97",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "900": {
+          "$type": "color",
+          "$value": "#1e2735",
+          "$description": "",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:183:691",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        },
+        "950": {
+          "$type": "color",
+          "$value": "#141419",
+          "$description": "Brand Color: Black",
+          "$extensions": {
+            "mode": {},
+            "figma": {
+              "variableId": "VariableID:28:656",
+              "collection": {
+                "id": "VariableCollectionId:2:5",
+                "name": "Primitives",
+                "defaultModeId": "2:0"
+              }
+            }
+          }
+        }
+      },
+      "accent": {
+        "red": {
+          "100": {
+            "$type": "color",
+            "$value": "#f6e9e6",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2435",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "200": {
+            "$type": "color",
+            "$value": "#f1ccc5",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:102",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "300": {
+            "$type": "color",
+            "$value": "#ecab9f",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:103",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "400": {
+            "$type": "color",
+            "$value": "#ea735d",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:104",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "500": {
+            "$type": "color",
+            "$value": "#eb4b2d",
+            "$description": "Brand Color: Bright Red",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:105",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "600": {
+            "$type": "color",
+            "$value": "#bf3b22",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:106",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "700": {
+            "$type": "color",
+            "$value": "#8c2815",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:107",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "800": {
+            "$type": "color",
+            "$value": "#621e11",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:21:108",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "900": {
+            "$type": "color",
+            "$value": "#51170c",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2436",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          }
+        },
+        "yellow": {
+          "100": {
+            "$type": "color",
+            "$value": "#f4eadb",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2438",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "200": {
+            "$type": "color",
+            "$value": "#f6e5cb",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:3",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "300": {
+            "$type": "color",
+            "$value": "#e9c791",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:4",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "400": {
+            "$type": "color",
+            "$value": "#e8b768",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:5",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "500": {
+            "$type": "color",
+            "$value": "#eba22d",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:6",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "600": {
+            "$type": "color",
+            "$value": "#c28728",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:7",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "700": {
+            "$type": "color",
+            "$value": "#9d6d1f",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:8",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "800": {
+            "$type": "color",
+            "$value": "#513810",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:9",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "900": {
+            "$type": "color",
+            "$value": "#462f0b",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2437",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          }
+        },
+        "brand": {
+          "100": {
+            "$type": "color",
+            "$value": "#f0ffe6",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2440",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "200": {
+            "$type": "color",
+            "$value": "#dbffc4",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:12",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "300": {
+            "$type": "color",
+            "$value": "#c8ffa5",
+            "$description": "Brand Color: Bright Green",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:13",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "400": {
+            "$type": "color",
+            "$value": "#a7eb7c",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:14",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "500": {
+            "$type": "color",
+            "$value": "#1ec866",
+            "$description": "Brand Color: Vivid Green",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:15",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "600": {
+            "$type": "color",
+            "$value": "#239d58",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:16",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "700": {
+            "$type": "color",
+            "$value": "#217846",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:17",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "800": {
+            "$type": "color",
+            "$value": "#1a5448",
+            "$description": "",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:22:18",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          },
+          "900": {
+            "$type": "color",
+            "$value": "#102924",
+            "$description": "Brand Color: Black-Green",
+            "$extensions": {
+              "mode": {},
+              "figma": {
+                "variableId": "VariableID:39:2439",
+                "collection": {
+                  "id": "VariableCollectionId:2:5",
+                  "name": "Primitives",
+                  "defaultModeId": "2:0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "shadow": {
+        "$type": "color",
+        "$value": "#14141933",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:132:1740",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
       }
     },
-    "weight": {
-      "$type": "fontWeight",
-
-      "extralight": { "$value": 200 },
-      "light": { "$value": 300 },
-      "regular": { "$value": 400 },
-      "book": { "$value": 450 },
-      "medium": { "$value": 500 },
-      "semibold": { "$value": 600 },
-      "bold": { "$value": 700 },
-      "extrabold": { "$value": 800 }
-    }
-  },
-  "h1": {
-    "$type": "typography",
-    "$value": {
-      "fontFamily": "{font.family.kurrent}",
-      "fontSize": "2.5rem",
-      "fontWeight": "{font.weight.regular}",
-      "letterSpacing": "normal",
-      "lineHeight": 1.4
-    }
-  },
-  "h2": {
-    "$type": "typography",
-    "$value": {
-      "fontFamily": "{font.family.kurrent}",
-      "fontSize": "2rem",
-      "fontWeight": "{font.weight.regular}",
-      "letterSpacing": "normal",
-      "lineHeight": 1.4
-    }
-  },
-  "h3": {
-    "$type": "typography",
-    "$value": {
-      "fontFamily": "{font.family.kurrent}",
-      "fontSize": "1.625rem",
-      "fontWeight": "{font.weight.regular}",
-      "letterSpacing": "normal",
-      "lineHeight": 1.4
-    }
-  },
-  "h4": {
-    "$type": "typography",
-    "$value": {
-      "fontFamily": "{font.family.kurrent}",
-      "fontSize": "1.375rem",
-      "fontWeight": "{font.weight.medium}",
-      "letterSpacing": "normal",
-      "lineHeight": 1.4
-    }
-  },
-  "h5": {
-    "$type": "typography",
-    "$value": {
-      "fontFamily": "{font.family.kurrent}",
-      "fontSize": "1.25rem",
-      "fontWeight": "{font.weight.bold}",
-      "letterSpacing": "normal",
-      "lineHeight": 1.4
-    }
-  },
-  "h6": {
-    "$type": "typography",
-    "$value": {
-      "fontFamily": "{font.family.kurrent}",
-      "fontSize": "1.125rem",
-      "fontWeight": "{font.weight.bold}",
-      "letterSpacing": "normal",
-      "lineHeight": 1.4
-    }
-  },
-  "text-large": {
-    "$type": "typography",
-    "$value": {
-      "fontFamily": "{font.family.grotesk}",
-      "fontSize": "1.125rem",
-      "fontWeight": "{font.weight.regular}",
-      "letterSpacing": "normal",
-      "lineHeight": 1.4
-    }
-  },
-  "text": {
-    "$type": "typography",
-    "$value": {
-      "fontFamily": "{font.family.grotesk}",
-      "fontSize": "1rem",
-      "fontWeight": "{font.weight.regular}",
-      "letterSpacing": "normal",
-      "lineHeight": 1.4
-    }
-  },
-  "text-small": {
-    "$type": "typography",
-    "$value": {
-      "fontFamily": "{font.family.grotesk}",
-      "fontSize": "0.875rem",
-      "fontWeight": "{font.weight.regular}",
-      "letterSpacing": "normal",
-      "lineHeight": 1.4
-    }
-  },
-  "color": {
-    "$type": "color",
-    "$description": "Palette of color primitives used throughout Atomic Playfulness.",
-
-    "neutral": {
-      "white": { "$value": "#FFFFFF" },
-      "black": { "$value": "#141419" }
+    "spacing": {
+      "1": {
+        "$type": "dimension",
+        "$value": "8px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:40",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "2": {
+        "$type": "dimension",
+        "$value": "16px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:41",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "3": {
+        "$type": "dimension",
+        "$value": "24px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:42",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "4": {
+        "$type": "dimension",
+        "$value": "32px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:43",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "5": {
+        "$type": "dimension",
+        "$value": "40px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:44",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "6": {
+        "$type": "dimension",
+        "$value": "48px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:45",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "7": {
+        "$type": "dimension",
+        "$value": "56px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:46",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "8": {
+        "$type": "dimension",
+        "$value": "64px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:47",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "9": {
+        "$type": "dimension",
+        "$value": "72px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:48",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "10": {
+        "$type": "dimension",
+        "$value": "80px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:49",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "half": {
+        "$type": "dimension",
+        "$value": "4px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:39",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      }
     },
-    "forest-green": {
-      "100": { "$value": "#549A79" },
-      "200": { "$value": "#478467" },
-      "300": { "$value": "#396D55" },
-      "400": { "$value": "#285340" },
-      "500": { "$value": "#1E4132" },
-      "600": { "$value": "#103527" },
-      "700": { "$value": "#102924" }
+    "radius": {
+      "sm": {
+        "$type": "dimension",
+        "$value": "4px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:50",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "md": {
+        "$type": "dimension",
+        "$value": "8px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:51",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "lg": {
+        "$type": "dimension",
+        "$value": "16px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:52",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "xl": {
+        "$type": "dimension",
+        "$value": "32px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:53",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "2xl": {
+        "$type": "dimension",
+        "$value": "128px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:54",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "3xl": {
+        "$type": "dimension",
+        "$value": "360px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:23:55",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      }
     },
-    "bright-green": {
-      "500": { "$value": "#C8FFA5" }
+    "font-family": {
+      "heading": {
+        "$type": "string",
+        "$value": "ES Klarheit Kurrent RD",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:2",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "body": {
+        "$type": "string",
+        "$value": "ES Klarheit Grotesk RD",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:3",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      }
     },
-    "blue-gray": {
-      "300": { "$value": "#F0F8FF" },
-      "400": { "$value": "#DCE4FB" },
-      "500": { "$value": "#C7CFEB" },
-      "600": { "$value": "#B3BCD3" },
-      "700": { "$value": "#9CA4B8" }
+    "font-size": {
+      "xs": {
+        "$type": "dimension",
+        "$value": "12px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:6",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "md": {
+        "$type": "dimension",
+        "$value": "16px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:7",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "s": {
+        "$type": "dimension",
+        "$value": "14px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:8",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "lg": {
+        "$type": "dimension",
+        "$value": "20px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:9",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "xl": {
+        "$type": "dimension",
+        "$value": "24px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:10",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "2xl": {
+        "$type": "dimension",
+        "$value": "32px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:11",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "3xl": {
+        "$type": "dimension",
+        "$value": "48px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:28:29",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "4xl": {
+        "$type": "dimension",
+        "$value": "64px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:28:30",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      }
+    },
+    "font-weight": {
+      "regular": {
+        "$type": "string",
+        "$value": "regular",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:12",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "medium": {
+        "$type": "string",
+        "$value": "medium",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:13",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "bold": {
+        "$type": "string",
+        "$value": "bold",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:14",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      }
+    },
+    "line-height": {
+      "2xs": {
+        "$type": "dimension",
+        "$value": "14px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:15",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "xs": {
+        "$type": "dimension",
+        "$value": "16px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:16",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "md": {
+        "$type": "dimension",
+        "$value": "24px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:17",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "lg": {
+        "$type": "dimension",
+        "$value": "28px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:18",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "xl": {
+        "$type": "dimension",
+        "$value": "32px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:19",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "2xl": {
+        "$type": "dimension",
+        "$value": "40px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:20",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "s": {
+        "$type": "dimension",
+        "$value": "20px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:25:50",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "3xl": {
+        "$type": "dimension",
+        "$value": "54px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:28:31",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "4xl": {
+        "$type": "dimension",
+        "$value": "64px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:28:32",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      }
+    },
+    "letter-spacing": {
+      "xs": {
+        "$type": "dimension",
+        "$value": "-0.20000000298023224px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:21",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "s": {
+        "$type": "dimension",
+        "$value": "-0.10000000149011612px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:22",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "md": {
+        "$type": "dimension",
+        "$value": "0px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:23",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "lg": {
+        "$type": "dimension",
+        "$value": "0.10000000149011612px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:24",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "xl": {
+        "$type": "dimension",
+        "$value": "0.20000000298023224px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:24:25",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      }
+    },
+    "opacity": {
+      "default": {
+        "$type": "dimension",
+        "$value": "100px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:39:2441",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "disabled": {
+        "$type": "dimension",
+        "$value": "25px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:39:2442",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      },
+      "inactive": {
+        "$type": "dimension",
+        "$value": "72px",
+        "$description": "",
+        "$extensions": {
+          "mode": {},
+          "figma": {
+            "variableId": "VariableID:83:2122",
+            "collection": {
+              "id": "VariableCollectionId:2:5",
+              "name": "Primitives",
+              "defaultModeId": "2:0"
+            }
+          }
+        }
+      }
+    }
+  },
+  "Tokens": {
+    "color": {
+      "background": {
+        "surface": {
+          "primary": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.50}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.50}",
+                  "Dark": "{Primitives.color.neutral.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:23:57",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.200}",
+                  "Dark": "{Primitives.color.neutral.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:673",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.300}",
+                  "Dark": "{Primitives.color.neutral.600}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:674",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "secondary": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.100}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.100}",
+                  "Dark": "{Primitives.color.neutral.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:23:58",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.200}",
+                  "Dark": "{Primitives.color.neutral.600}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:683",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.300}",
+                  "Dark": "{Primitives.color.neutral.500}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:684",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "invert": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.900}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.900}",
+                  "Dark": "{Primitives.color.neutral.50}"
+                },
+                "figma": {
+                  "variableId": "VariableID:23:60",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.800}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.800}",
+                  "Dark": "{Primitives.color.neutral.100}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:691",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.700}",
+                  "Dark": "{Primitives.color.neutral.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:692",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "brand": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.900}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.900}",
+                  "Dark": "{Primitives.color.accent.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:23:61",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.800}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.800}",
+                  "Dark": "{Primitives.color.accent.brand.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:699",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.700}",
+                  "Dark": "{Primitives.color.accent.brand.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:29:700",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "warning": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.yellow.100}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.yellow.100}",
+                  "Dark": "{Primitives.color.accent.yellow.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:71:820",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.yellow.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.yellow.200}",
+                  "Dark": "{Primitives.color.accent.yellow.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:71:821",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.yellow.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.yellow.300}",
+                  "Dark": "{Primitives.color.accent.yellow.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:71:822",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "error": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.red.100}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.red.100}",
+                  "Dark": "{Primitives.color.accent.red.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:71:824",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.red.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.red.200}",
+                  "Dark": "{Primitives.color.accent.red.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:71:825",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.red.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.red.300}",
+                  "Dark": "{Primitives.color.accent.red.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:71:826",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "success": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.100}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.100}",
+                  "Dark": "{Primitives.color.accent.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:71:827",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.200}",
+                  "Dark": "{Primitives.color.accent.brand.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:71:828",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.300}",
+                  "Dark": "{Primitives.color.accent.brand.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:71:829",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "tertiary": {
+            "default": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.300}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.300}",
+                  "Dark": "{Primitives.color.neutral.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:143:1997",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "hovered": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.400}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.400}",
+                  "Dark": "{Primitives.color.neutral.600}"
+                },
+                "figma": {
+                  "variableId": "VariableID:143:1998",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "pressed": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.500}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.500}",
+                  "Dark": "{Primitives.color.neutral.500}"
+                },
+                "figma": {
+                  "variableId": "VariableID:143:1999",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "button": {
+          "primary": {
+            "onLight": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.900}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.900}",
+                    "Dark": "{Primitives.color.accent.brand.300}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:29:665",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.800}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.800}",
+                    "Dark": "{Primitives.color.accent.brand.400}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:29:669",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.700}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.700}",
+                    "Dark": "{Primitives.color.accent.brand.500}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:29:670",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            },
+            "onDark": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.300}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.300}",
+                    "Dark": "{Primitives.color.accent.brand.700}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:78:1205",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.400}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.400}",
+                    "Dark": "{Primitives.color.accent.brand.600}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:78:1206",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.500}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.500}",
+                    "Dark": "{Primitives.color.accent.brand.500}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:78:1207",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "secondary": {
+            "onLight": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.neutral.50}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.neutral.50}",
+                    "Dark": "{Primitives.color.neutral.50}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:78:1408",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.100}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.100}",
+                    "Dark": "{Primitives.color.accent.brand.600}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:78:1409",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.200}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.200}",
+                    "Dark": "{Primitives.color.accent.brand.500}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:78:1410",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            },
+            "onDark": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.700}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.700}",
+                    "Dark": "{Primitives.color.accent.brand.700}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:78:1411",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.600}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.600}",
+                    "Dark": "{Primitives.color.accent.brand.600}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:78:1412",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.500}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.500}",
+                    "Dark": "{Primitives.color.accent.brand.500}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:78:1413",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "tertiary": {
+            "onLight": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.neutral.50}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.neutral.50}",
+                    "Dark": "{Primitives.color.neutral.50}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1846",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.100}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.100}",
+                    "Dark": "{Primitives.color.accent.brand.100}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1847",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.200}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.200}",
+                    "Dark": "{Primitives.color.accent.brand.200}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1848",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            },
+            "onDark": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.neutral.50}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.neutral.50}",
+                    "Dark": "{Primitives.color.neutral.50}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1849",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.green.800}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.green.800}",
+                    "Dark": "{Primitives.color.accent.brand.100}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1850",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.green.700}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.green.700}",
+                    "Dark": "{Primitives.color.accent.brand.200}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1851",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "brand": {
+            "onLight": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.900}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.900}",
+                    "Dark": "{Primitives.color.accent.brand.300}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1852",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.800}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.800}",
+                    "Dark": "{Primitives.color.accent.brand.400}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1853",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.700}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.700}",
+                    "Dark": "{Primitives.color.accent.brand.500}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1854",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            },
+            "onDark": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.300}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.300}",
+                    "Dark": "{Primitives.color.accent.brand.900}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1855",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.400}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.400}",
+                    "Dark": "{Primitives.color.accent.brand.800}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1856",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.brand.500}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.brand.500}",
+                    "Dark": "{Primitives.color.accent.brand.600}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1857",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "destructive": {
+            "onLight": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.red.600}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.red.600}",
+                    "Dark": "{Primitives.color.accent.red.600}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1858",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.red.500}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.red.500}",
+                    "Dark": "{Primitives.color.accent.red.500}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1859",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.red.400}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.red.400}",
+                    "Dark": "{Primitives.color.accent.red.400}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1860",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            },
+            "onDark": {
+              "default": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.red.200}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.red.200}",
+                    "Dark": "{Primitives.color.accent.red.600}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1861",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "hovered": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.red.300}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.red.300}",
+                    "Dark": "{Primitives.color.accent.red.500}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1862",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              },
+              "pressed": {
+                "$type": "color",
+                "$value": "{Primitives.color.accent.red.400}",
+                "$description": "",
+                "$extensions": {
+                  "mode": {
+                    "Light": "{Primitives.color.accent.red.400}",
+                    "Dark": "{Primitives.color.accent.red.400}"
+                  },
+                  "figma": {
+                    "variableId": "VariableID:83:1863",
+                    "collection": {
+                      "id": "VariableCollectionId:23:56",
+                      "name": "Tokens",
+                      "defaultModeId": "23:0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "textfield": {
+          "default": {
+            "$type": "color",
+            "$value": "{Primitives.color.neutral.50}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.neutral.50}",
+                "Dark": "{Primitives.color.neutral.800}"
+              },
+              "figma": {
+                "variableId": "VariableID:131:1678",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "badge": {
+          "positive": {
+            "dark": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.900}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.900}",
+                  "Dark": "{Primitives.color.accent.brand.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3774",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "light": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.200}",
+                  "Dark": "{Primitives.color.accent.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3775",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "caution": {
+            "dark": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.yellow.900}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.yellow.900}",
+                  "Dark": "{Primitives.color.accent.yellow.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3805",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "light": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.yellow.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.yellow.200}",
+                  "Dark": "{Primitives.color.accent.yellow.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3806",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "critical": {
+            "dark": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.red.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.red.700}",
+                  "Dark": "{Primitives.color.accent.red.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3821",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "light": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.red.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.red.200}",
+                  "Dark": "{Primitives.color.accent.red.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3822",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "neutral": {
+            "dark": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.800}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.800}",
+                  "Dark": "{Primitives.color.neutral.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3838",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "light": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.200}",
+                  "Dark": "{Primitives.color.neutral.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3839",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "text": {
+        "primary": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.neutral.800}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.neutral.800}",
+                "Dark": "{Primitives.color.neutral.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:23:72",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.neutral.100}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.neutral.100}",
+                "Dark": "{Primitives.color.neutral.800}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:159",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "secondary": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.neutral.700}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.neutral.700}",
+                "Dark": "{Primitives.color.neutral.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:23:73",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.neutral.200}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.neutral.200}",
+                "Dark": "{Primitives.color.neutral.700}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:160",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "brand": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.accent.brand.900}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.accent.brand.900}",
+                "Dark": "{Primitives.color.accent.brand.300}"
+              },
+              "figma": {
+                "variableId": "VariableID:23:74",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.accent.brand.300}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.accent.brand.300}",
+                "Dark": "{Primitives.color.accent.brand.900}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:161",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "warning": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.accent.yellow.900}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.accent.yellow.900}",
+                "Dark": "{Primitives.color.accent.yellow.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:39:2434",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.accent.yellow.100}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.accent.yellow.100}",
+                "Dark": "{Primitives.color.accent.yellow.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:71:850",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "error": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.accent.red.700}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.accent.red.700}",
+                "Dark": "{Primitives.color.accent.red.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:71:830",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.accent.red.100}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.accent.red.100}",
+                "Dark": "{Primitives.color.accent.red.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:71:851",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "success": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.accent.brand.900}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.accent.brand.900}",
+                "Dark": "{Primitives.color.accent.brand.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:71:831",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDqark": {
+            "$type": "color",
+            "$value": "{Primitives.color.accent.brand.100}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.accent.brand.100}",
+                "Dark": "{Primitives.color.accent.brand.100}"
+              },
+              "figma": {
+                "variableId": "VariableID:131:1699",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "tertiary": {
+          "onLight": {
+            "$type": "color",
+            "$value": "{Primitives.color.neutral.700}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.neutral.700}",
+                "Dark": "{Primitives.color.neutral.200}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:162",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          },
+          "onDark": {
+            "$type": "color",
+            "$value": "{Primitives.color.neutral.200}",
+            "$description": "",
+            "$extensions": {
+              "mode": {
+                "Light": "{Primitives.color.neutral.200}",
+                "Dark": "{Primitives.color.neutral.700}"
+              },
+              "figma": {
+                "variableId": "VariableID:78:163",
+                "collection": {
+                  "id": "VariableCollectionId:23:56",
+                  "name": "Tokens",
+                  "defaultModeId": "23:0"
+                }
+              }
+            }
+          }
+        },
+        "badge": {
+          "positive": {
+            "dark": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.900}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.900}",
+                  "Dark": "{Primitives.color.accent.brand.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3776",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "light": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.brand.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.brand.200}",
+                  "Dark": "{Primitives.color.accent.brand.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3777",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "caution": {
+            "dark": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.yellow.900}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.yellow.900}",
+                  "Dark": "{Primitives.color.accent.yellow.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3807",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "light": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.yellow.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.yellow.200}",
+                  "Dark": "{Primitives.color.accent.yellow.900}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3808",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "critical": {
+            "dark": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.red.700}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.red.700}",
+                  "Dark": "{Primitives.color.accent.red.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3823",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "light": {
+              "$type": "color",
+              "$value": "{Primitives.color.accent.red.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.accent.red.200}",
+                  "Dark": "{Primitives.color.accent.red.700}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3824",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          },
+          "neutral": {
+            "dark": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.800}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.800}",
+                  "Dark": "{Primitives.color.neutral.200}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3840",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            },
+            "light": {
+              "$type": "color",
+              "$value": "{Primitives.color.neutral.200}",
+              "$description": "",
+              "$extensions": {
+                "mode": {
+                  "Light": "{Primitives.color.neutral.200}",
+                  "Dark": "{Primitives.color.neutral.800}"
+                },
+                "figma": {
+                  "variableId": "VariableID:144:3841",
+                  "collection": {
+                    "id": "VariableCollectionId:23:56",
+                    "name": "Tokens",
+                    "defaultModeId": "23:0"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "link": {
+        "default": {
+          "$type": "color",
+          "$value": "{Primitives.color.green.900}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.green.900}",
+              "Dark": "{Primitives.color.green.100}"
+            },
+            "figma": {
+              "variableId": "VariableID:29:703",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "hovered": {
+          "$type": "color",
+          "$value": "{Primitives.color.green.800}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.green.800}",
+              "Dark": "{Primitives.color.green.200}"
+            },
+            "figma": {
+              "variableId": "VariableID:71:832",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "pressed": {
+          "$type": "color",
+          "$value": "{Primitives.color.green.700}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.green.700}",
+              "Dark": "{Primitives.color.green.300}"
+            },
+            "figma": {
+              "variableId": "VariableID:71:833",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "spacing": {
+      "none": {
+        "$type": "dimension",
+        "$value": "0px",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "0px",
+            "Dark": "0px"
+          },
+          "figma": {
+            "variableId": "VariableID:23:62",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "xs": {
+        "$type": "dimension",
+        "$value": "{Primitives.spacing.half}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.spacing.half}",
+            "Dark": "{Primitives.spacing.half}"
+          },
+          "figma": {
+            "variableId": "VariableID:23:63",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "md": {
+        "$type": "dimension",
+        "$value": "{Primitives.spacing.2}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.spacing.2}",
+            "Dark": "{Primitives.spacing.2}"
+          },
+          "figma": {
+            "variableId": "VariableID:23:64",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "sm": {
+        "$type": "dimension",
+        "$value": "{Primitives.spacing.1}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.spacing.1}",
+            "Dark": "{Primitives.spacing.1}"
+          },
+          "figma": {
+            "variableId": "VariableID:23:65",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "lg": {
+        "$type": "dimension",
+        "$value": "{Primitives.spacing.4}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.spacing.4}",
+            "Dark": "{Primitives.spacing.4}"
+          },
+          "figma": {
+            "variableId": "VariableID:23:66",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "xl": {
+        "$type": "dimension",
+        "$value": "{Primitives.spacing.6}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.spacing.6}",
+            "Dark": "{Primitives.spacing.6}"
+          },
+          "figma": {
+            "variableId": "VariableID:23:67",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "spacing-2xl": {
+        "$type": "dimension",
+        "$value": "{Primitives.spacing.10}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.spacing.10}",
+            "Dark": "{Primitives.spacing.10}"
+          },
+          "figma": {
+            "variableId": "VariableID:23:68",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "md-lg": {
+        "$type": "dimension",
+        "$value": "{Primitives.spacing.3}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.spacing.3}",
+            "Dark": "{Primitives.spacing.3}"
+          },
+          "figma": {
+            "variableId": "VariableID:215:637",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      }
+    },
+    "radius": {
+      "minimal": {
+        "$type": "dimension",
+        "$value": "{Primitives.radius.sm}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.radius.sm}",
+            "Dark": "{Primitives.radius.sm}"
+          },
+          "figma": {
+            "variableId": "VariableID:23:69",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": "{Primitives.radius.md}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.radius.md}",
+            "Dark": "{Primitives.radius.md}"
+          },
+          "figma": {
+            "variableId": "VariableID:23:70",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "radius-full": {
+        "$type": "dimension",
+        "$value": "{Primitives.radius.3xl}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.radius.3xl}",
+            "Dark": "{Primitives.radius.3xl}"
+          },
+          "figma": {
+            "variableId": "VariableID:23:71",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      }
+    },
+    "border": {
+      "primary": {
+        "onLight": {
+          "$type": "color",
+          "$value": "{Primitives.color.green.900}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.green.900}",
+              "Dark": "{Primitives.color.green.600}"
+            },
+            "figma": {
+              "variableId": "VariableID:23:76",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "onDark": {
+          "$type": "color",
+          "$value": "{Primitives.color.green.600}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.green.600}",
+              "Dark": "{Primitives.color.accent.brand.900}"
+            },
+            "figma": {
+              "variableId": "VariableID:78:1414",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "secondary": {
+        "onLight": {
+          "$type": "color",
+          "$value": "{Primitives.color.green.600}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.green.600}",
+              "Dark": "{Primitives.color.green.400}"
+            },
+            "figma": {
+              "variableId": "VariableID:23:77",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "onDark": {
+          "$type": "color",
+          "$value": "{Primitives.color.green.400}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.green.400}",
+              "Dark": "{Primitives.color.green.600}"
+            },
+            "figma": {
+              "variableId": "VariableID:78:1415",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "focused": {
+        "onLight": {
+          "$type": "color",
+          "$value": "{Primitives.color.accent.brand.500}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.accent.brand.500}",
+              "Dark": "{Primitives.color.accent.brand.500}"
+            },
+            "figma": {
+              "variableId": "VariableID:38:353",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "onDark": {
+          "$type": "color",
+          "$value": "{Primitives.color.accent.brand.500}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.accent.brand.500}",
+              "Dark": "{Primitives.color.accent.brand.500}"
+            },
+            "figma": {
+              "variableId": "VariableID:171:597",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "tertiary": {
+        "onLight": {
+          "$type": "color",
+          "$value": "{Primitives.color.neutral.200}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.neutral.200}",
+              "Dark": "{Primitives.color.neutral.700}"
+            },
+            "figma": {
+              "variableId": "VariableID:108:485",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "onDark": {
+          "$type": "color",
+          "$value": "{Primitives.color.neutral.700}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.neutral.700}",
+              "Dark": "{Primitives.color.neutral.700}"
+            },
+            "figma": {
+              "variableId": "VariableID:108:486",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "error": {
+        "onLight": {
+          "$type": "color",
+          "$value": "{Primitives.color.accent.red.700}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.accent.red.700}",
+              "Dark": "{Primitives.color.accent.red.300}"
+            },
+            "figma": {
+              "variableId": "VariableID:127:1004",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "onDark": {
+          "$type": "color",
+          "$value": "{Primitives.color.accent.red.300}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.accent.red.300}",
+              "Dark": "{Primitives.color.accent.red.300}"
+            },
+            "figma": {
+              "variableId": "VariableID:127:1005",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "brand": {
+        "onLight": {
+          "$type": "color",
+          "$value": "{Primitives.color.accent.brand.500}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.accent.brand.500}",
+              "Dark": "{Primitives.color.accent.brand.500}"
+            },
+            "figma": {
+              "variableId": "VariableID:131:1675",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "onDark": {
+          "$type": "color",
+          "$value": "{Primitives.color.accent.brand.300}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.accent.brand.300}",
+              "Dark": "{Primitives.color.accent.brand.300}"
+            },
+            "figma": {
+              "variableId": "VariableID:131:1676",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "typography": {
+      "font-family": {
+        "heading": {
+          "$type": "string",
+          "$value": "{Primitives.font-family.heading}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-family.heading}",
+              "Dark": "{Primitives.font-family.heading}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:28",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "body": {
+          "$type": "string",
+          "$value": "{Primitives.font-family.body}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-family.body}",
+              "Dark": "{Primitives.font-family.body}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:29",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "font-weight": {
+        "regular": {
+          "$type": "string",
+          "$value": "{Primitives.font-weight.regular}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-weight.regular}",
+              "Dark": "{Primitives.font-weight.regular}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:30",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "medium": {
+          "$type": "string",
+          "$value": "{Primitives.font-weight.medium}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-weight.medium}",
+              "Dark": "{Primitives.font-weight.medium}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:31",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "bold": {
+          "$type": "string",
+          "$value": "{Primitives.font-weight.bold}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-weight.bold}",
+              "Dark": "{Primitives.font-weight.bold}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:32",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "font-size": {
+        "h1": {
+          "$type": "dimension",
+          "$value": "{Primitives.font-size.4xl}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-size.4xl}",
+              "Dark": "{Primitives.font-size.4xl}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:33",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h2": {
+          "$type": "dimension",
+          "$value": "{Primitives.font-size.3xl}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-size.3xl}",
+              "Dark": "{Primitives.font-size.3xl}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:34",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h3": {
+          "$type": "dimension",
+          "$value": "{Primitives.font-size.2xl}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-size.2xl}",
+              "Dark": "{Primitives.font-size.2xl}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:35",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h4": {
+          "$type": "dimension",
+          "$value": "{Primitives.font-size.xl}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-size.xl}",
+              "Dark": "{Primitives.font-size.xl}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:36",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h5": {
+          "$type": "dimension",
+          "$value": "{Primitives.font-size.lg}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-size.lg}",
+              "Dark": "{Primitives.font-size.lg}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:37",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h6": {
+          "$type": "dimension",
+          "$value": "{Primitives.font-size.md}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-size.md}",
+              "Dark": "{Tokens.spacing.md}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:38",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "body-regular": {
+          "$type": "dimension",
+          "$value": "{Primitives.font-size.md}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-size.md}",
+              "Dark": "{Primitives.font-size.md}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:39",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "body-small": {
+          "$type": "dimension",
+          "$value": "{Primitives.font-size.s}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-size.s}",
+              "Dark": "{Primitives.font-size.s}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:40",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "footnotes": {
+          "$type": "dimension",
+          "$value": "{Primitives.font-size.xs}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.font-size.xs}",
+              "Dark": "{Primitives.font-size.xs}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:41",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "line-height": {
+        "h1": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.4xl}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.4xl}",
+              "Dark": "{Primitives.line-height.4xl}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:42",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h2": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.3xl}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.3xl}",
+              "Dark": "{Primitives.line-height.3xl}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:43",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h3": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.2xl}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.2xl}",
+              "Dark": "{Primitives.line-height.2xl}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:44",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h4": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.xl}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.xl}",
+              "Dark": "{Primitives.line-height.xl}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:45",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h5": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.lg}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.lg}",
+              "Dark": "{Primitives.line-height.lg}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:46",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "h6": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.md}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.md}",
+              "Dark": "{Primitives.line-height.md}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:47",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "body-regular-singleline": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.md}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.md}",
+              "Dark": "{Primitives.line-height.md}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:49",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "body-regular-multiline": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.s}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.s}",
+              "Dark": "{Primitives.line-height.s}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:51",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "body-small-singleline": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.xs}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.xs}",
+              "Dark": "{Primitives.line-height.xs}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:52",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "body-small-multiline": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.xs}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.xs}",
+              "Dark": "{Primitives.line-height.xs}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:53",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "footnotes-singleeline": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.xs}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.xs}",
+              "Dark": "{Primitives.line-height.xs}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:54",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "footnotes-multiline": {
+          "$type": "dimension",
+          "$value": "{Primitives.line-height.xs}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.line-height.xs}",
+              "Dark": "{Primitives.line-height.xs}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:55",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      },
+      "letter-spacing": {
+        "md": {
+          "$type": "dimension",
+          "$value": "{Primitives.letter-spacing.md}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.letter-spacing.md}",
+              "Dark": "{Primitives.letter-spacing.md}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:56",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "lg": {
+          "$type": "dimension",
+          "$value": "{Primitives.letter-spacing.lg}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.letter-spacing.lg}",
+              "Dark": "{Primitives.letter-spacing.lg}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:57",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "xl": {
+          "$type": "dimension",
+          "$value": "{Primitives.letter-spacing.xl}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.letter-spacing.xl}",
+              "Dark": "{Primitives.letter-spacing.xl}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:58",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "s": {
+          "$type": "dimension",
+          "$value": "{Primitives.letter-spacing.s}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.letter-spacing.s}",
+              "Dark": "{Primitives.letter-spacing.s}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:59",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "xs": {
+          "$type": "dimension",
+          "$value": "{Primitives.letter-spacing.xs}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.letter-spacing.xs}",
+              "Dark": "{Primitives.letter-spacing.xs}"
+            },
+            "figma": {
+              "variableId": "VariableID:25:60",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "opacity": {
+      "default": {
+        "$type": "dimension",
+        "$value": "{Primitives.opacity.default}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.opacity.default}",
+            "Dark": "{Primitives.opacity.default}"
+          },
+          "figma": {
+            "variableId": "VariableID:39:2444",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "disabled": {
+        "$type": "dimension",
+        "$value": "{Primitives.opacity.disabled}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.opacity.disabled}",
+            "Dark": "{Primitives.opacity.disabled}"
+          },
+          "figma": {
+            "variableId": "VariableID:39:2445",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      },
+      "inactive": {
+        "$type": "dimension",
+        "$value": "{Primitives.opacity.inactive}",
+        "$description": "",
+        "$extensions": {
+          "mode": {
+            "Light": "{Primitives.opacity.inactive}",
+            "Dark": "{Primitives.opacity.inactive}"
+          },
+          "figma": {
+            "variableId": "VariableID:83:2123",
+            "collection": {
+              "id": "VariableCollectionId:23:56",
+              "name": "Tokens",
+              "defaultModeId": "23:0"
+            }
+          }
+        }
+      }
+    },
+    "shadow": {
+      "first level": {
+        "color": {
+          "$type": "color",
+          "$value": "{Primitives.color.shadow}",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "{Primitives.color.shadow}",
+              "Dark": "{Primitives.color.shadow}"
+            },
+            "figma": {
+              "variableId": "VariableID:132:1741",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "x": {
+          "$type": "dimension",
+          "$value": "0px",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "0px",
+              "Dark": "0px"
+            },
+            "figma": {
+              "variableId": "VariableID:132:1742",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "y": {
+          "$type": "dimension",
+          "$value": "2px",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "2px",
+              "Dark": "2px"
+            },
+            "figma": {
+              "variableId": "VariableID:132:1743",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        },
+        "blur": {
+          "$type": "dimension",
+          "$value": "4px",
+          "$description": "",
+          "$extensions": {
+            "mode": {
+              "Light": "4px",
+              "Dark": "4px"
+            },
+            "figma": {
+              "variableId": "VariableID:132:1744",
+              "collection": {
+                "id": "VariableCollectionId:23:56",
+                "name": "Tokens",
+                "defaultModeId": "23:0"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$extensions": {
+    "tokens-bruecke-meta": {
+      "useDTCGKeys": true,
+      "colorMode": "hex",
+      "variableCollections": ["Primitives", "Tokens"],
+      "createdAt": "2024-10-18T12:52:37.979Z"
     }
   }
 }

--- a/packages/foundation/src/elements/typography.css
+++ b/packages/foundation/src/elements/typography.css
@@ -1,77 +1,77 @@
 /* Headings */
 
 .hap-h1 {
-  font-family: var(--hap-h1-font-family);
-  font-size: var(--hap-h1-font-size);
-  font-weight: var(--hap-h1-font-weight);
-  letter-spacing: var(--hap-h1-letter-spacing);
-  line-height: var(--hap-h1-line-height);
+  font-family: var(--hap-typography-font-family-heading);
+  font-size: var(--hap-typography-font-size-h1);
+  font-weight: var(--hap-typography-font-weight-bold);
+  letter-spacing: normal;
+  line-height: var(--hap-typography-line-height-h1);
 }
 
 .hap-h2 {
-  font-family: var(--hap-h2-font-family);
-  font-size: var(--hap-h2-font-size);
-  font-weight: var(--hap-h2-font-weight);
-  letter-spacing: var(--hap-h2-letter-spacing);
-  line-height: var(--hap-h2-line-height);
+  font-family: var(--hap-typography-font-family-heading);
+  font-size: var(--hap-typography-font-size-h2);
+  font-weight: var(--hap-typography-font-weight-medium);
+  letter-spacing: normal;
+  line-height: var(--hap-typography-line-height-h2);
 }
 
 .hap-h3 {
-  font-family: var(--hap-h3-font-family);
-  font-size: var(--hap-h3-font-size);
-  font-weight: var(--hap-h3-font-weight);
-  letter-spacing: var(--hap-h3-letter-spacing);
-  line-height: var(--hap-h3-line-height);
+  font-family: var(--hap-typography-font-family-heading);
+  font-size: var(--hap-typography-font-size-h3);
+  font-weight: var(--hap-typography-font-weight-medium);
+  letter-spacing: normal;
+  line-height: var(--hap-typography-line-height-h3);
 }
 
 .hap-h4 {
-  font-family: var(--hap-h4-font-family);
-  font-size: var(--hap-h4-font-size);
-  font-weight: var(--hap-h4-font-weight);
-  letter-spacing: var(--hap-h4-letter-spacing);
-  line-height: var(--hap-h4-line-height);
+  font-family: var(--hap-typography-font-family-heading);
+  font-size: var(--hap-typography-font-size-h4);
+  font-weight: var(--hap-typography-font-weight-medium);
+  letter-spacing: normal;
+  line-height: var(--hap-typography-line-height-h4);
 }
 
 .hap-h5 {
-  font-family: var(--hap-h5-font-family);
-  font-size: var(--hap-h5-font-size);
-  font-weight: var(--hap-h5-font-weight);
-  letter-spacing: var(--hap-h5-letter-spacing);
-  line-height: var(--hap-h5-line-height);
+  font-family: var(--hap-typography-font-family-heading);
+  font-size: var(--hap-typography-font-size-h5);
+  font-weight: var(--hap-typography-font-weight-medium);
+  letter-spacing: normal;
+  line-height: var(--hap-typography-line-height-h5);
 }
 
 .hap-h6 {
-  font-family: var(--hap-h6-font-family);
-  font-size: var(--hap-h6-font-size);
-  font-weight: var(--hap-h6-font-weight);
-  letter-spacing: var(--hap-h6-letter-spacing);
-  line-height: var(--hap-h6-line-height);
+  font-family: var(--hap-typography-font-family-heading);
+  font-size: var(--hap-typography-font-size-h6);
+  font-weight: var(--hap-typography-font-weight-medium);
+  letter-spacing: normal;
+  line-height: var(--hap-typography-line-height-h6);
 }
 
 /* Body text */
 
 .hap-text-large {
-  font-family: var(--hap-text-large-font-family);
-  font-size: var(--hap-text-large-font-size);
-  font-weight: var(--hap-text-large-font-weight);
-  letter-spacing: var(--hap-text-large-letter-spacing);
-  line-height: var(--hap-text-large-line-height);
+  font-family: var(--hap-typography-font-family-body);
+  font-size: var(--hap-typography-font-size-h5);
+  font-weight: var(--hap-typography-font-weight-regular);
+  letter-spacing: normal;
+  line-height: var(--hap-typography-line-height-h6);
 }
 
 .hap-text {
-  font-family: var(--hap-text-font-family);
-  font-size: var(--hap-text-font-size);
-  font-weight: var(--hap-text-font-weight);
-  letter-spacing: var(--hap-text-letter-spacing);
-  line-height: var(--hap-text-line-height);
+  font-family: var(--hap-typography-font-family-body);
+  font-size: var(--hap-typography-font-size-body-regular);
+  font-weight: var(--hap-typography-font-weight-regular);
+  letter-spacing: normal;
+  line-height: var(--hap-typography-line-height-body-regular-singleline);
 }
 
 .hap-text-small {
-  font-family: var(--hap-text-small-font-family);
-  font-size: var(--hap-text-small-font-size);
-  font-weight: var(--hap-text-small-font-weight);
-  letter-spacing: var(--hap-text-small-letter-spacing);
-  line-height: var(--hap-text-small-line-height);
+  font-family: var(--hap-typography-font-family-body);
+  font-size: var(--hap-typography-font-size-body-small);
+  font-weight: var(--hap-typography-font-weight-regular);
+  letter-spacing: normal;
+  line-height: var(--hap-typography-line-height-body-small-singleline);
 }
 
 /* Rounded Dots for all typography levels */

--- a/packages/foundation/src/elements/typography.css
+++ b/packages/foundation/src/elements/typography.css
@@ -1,6 +1,7 @@
 /* Headings */
 
 .hap-h1 {
+  color: var(--hap-color-text-primary-onlight);
   font-family: var(--hap-typography-font-family-heading);
   font-size: var(--hap-typography-font-size-h1);
   font-weight: var(--hap-typography-font-weight-bold);
@@ -9,6 +10,7 @@
 }
 
 .hap-h2 {
+  color: var(--hap-color-text-primary-onlight);
   font-family: var(--hap-typography-font-family-heading);
   font-size: var(--hap-typography-font-size-h2);
   font-weight: var(--hap-typography-font-weight-medium);
@@ -17,6 +19,7 @@
 }
 
 .hap-h3 {
+  color: var(--hap-color-text-primary-onlight);
   font-family: var(--hap-typography-font-family-heading);
   font-size: var(--hap-typography-font-size-h3);
   font-weight: var(--hap-typography-font-weight-medium);
@@ -25,6 +28,7 @@
 }
 
 .hap-h4 {
+  color: var(--hap-color-text-primary-onlight);
   font-family: var(--hap-typography-font-family-heading);
   font-size: var(--hap-typography-font-size-h4);
   font-weight: var(--hap-typography-font-weight-medium);
@@ -33,6 +37,7 @@
 }
 
 .hap-h5 {
+  color: var(--hap-color-text-primary-onlight);
   font-family: var(--hap-typography-font-family-heading);
   font-size: var(--hap-typography-font-size-h5);
   font-weight: var(--hap-typography-font-weight-medium);
@@ -41,6 +46,7 @@
 }
 
 .hap-h6 {
+  color: var(--hap-color-text-primary-onlight);
   font-family: var(--hap-typography-font-family-heading);
   font-size: var(--hap-typography-font-size-h6);
   font-weight: var(--hap-typography-font-weight-medium);
@@ -51,6 +57,7 @@
 /* Body text */
 
 .hap-text-large {
+  color: var(--hap-color-text-primary-onlight);
   font-family: var(--hap-typography-font-family-body);
   font-size: var(--hap-typography-font-size-h5);
   font-weight: var(--hap-typography-font-weight-regular);
@@ -59,6 +66,7 @@
 }
 
 .hap-text {
+  color: var(--hap-color-text-primary-onlight);
   font-family: var(--hap-typography-font-family-body);
   font-size: var(--hap-typography-font-size-body-regular);
   font-weight: var(--hap-typography-font-weight-regular);
@@ -67,6 +75,7 @@
 }
 
 .hap-text-small {
+  color: var(--hap-color-text-primary-onlight);
   font-family: var(--hap-typography-font-family-body);
   font-size: var(--hap-typography-font-size-body-small);
   font-weight: var(--hap-typography-font-weight-regular);

--- a/packages/foundation/tokens.config.mjs
+++ b/packages/foundation/tokens.config.mjs
@@ -1,4 +1,9 @@
-import pluginCSS, { makeNameGenerator } from "@cobalt-ui/plugin-css";
+import pluginCSS, {
+  defaultNameGenerator,
+  makeNameGenerator,
+} from "@cobalt-ui/plugin-css";
+
+const prefix = "hap";
 
 /** @type {import("@cobalt-ui/core").Config} */
 export default {
@@ -6,7 +11,12 @@ export default {
   outDir: "./dist",
   plugins: [
     pluginCSS({
-      generateName: makeNameGenerator(undefined, "hap"),
+      generateName: makeNameGenerator((id) => {
+        // Remove "Tokens" from variable names for better usage and to match Figma's inspector
+        return defaultNameGenerator(id, prefix)
+          .toLowerCase()
+          .replace("hap-tokens", "hap");
+      }, prefix),
       transform: (token) => (token.$type === "string" ? token.value : void 0),
     }),
   ],

--- a/packages/foundation/tokens.config.mjs
+++ b/packages/foundation/tokens.config.mjs
@@ -7,6 +7,7 @@ export default {
   plugins: [
     pluginCSS({
       generateName: makeNameGenerator(undefined, "hap"),
+      transform: (token) => (token.$type === "string" ? token.value : void 0),
     }),
   ],
 };


### PR DESCRIPTION
Adds the latest set of design tokens exported from Figma. For the most part the typography has been updated with the tokens. However, we should do a separate pass on it as it has been mostly guesswork - we do not really have typography in Figma.

The color documentation now documents all primitive color palettes. I am a bit clueless how  we can ((and if we should)) document the semantic colors meaning way.