### PR TITLE
fix(foundation): css sources are not distributed

### DIFF
--- a/.changeset/gorgeous-donkeys-laugh.md
+++ b/.changeset/gorgeous-donkeys-laugh.md
@@ -1,0 +1,5 @@
+---
+"@holisticon/hap-foundation": patch
+---
+
+Included missing CSS files in package distribution. Now, provided fonts and documented imports should actually work.

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -8,6 +8,7 @@
   "files": [
     "./atomic-playfulness.tokens.json",
     "dist",
+    "src",
     "CHANGELOG.md",
     "README.md"
   ],


### PR DESCRIPTION
Our package distribution is missing critical CSS files from the source folder. https://www.npmjs.com/package/@holisticon/hap-foundation?activeTab=code

The easiest fix is to distribute the source folder as well, especially since it does not currently contain files that have to be transpiled. Later, we might think about moving CSS files to a "dist" folder in a build step.