### PR TITLE
refactor(checkbox): overhaul checkbox styles to match updated design

### DIFF
--- a/packages/documentation/src/elements/checkbox/checkbox.mdx
+++ b/packages/documentation/src/elements/checkbox/checkbox.mdx
@@ -1,16 +1,29 @@
 import { Meta, Canvas } from "@storybook/blocks";
-import * as checkboxStories from "./checkbox.stories.ts";
+import * as stories from "./checkbox.stories.ts";
 
-<Meta of={checkboxStories} />
+<Meta of={stories} />
 
 # Checkbox
 
-The following kinds of Checkboxs are available.
+Interaction element for using optional selection. The intermediate state is used
+when there is a partial selection within groups.
 
-## checkbox Default
+<Canvas of={stories.Default} />
 
-<Canvas of={checkboxStories.Default} />
+## Variants
 
-## checkbox Error
+### Default
 
-<Canvas of={checkboxStories.Error} />
+<Canvas of={stories.Default} />
+
+## Intermediate
+
+<Canvas of={stories.Intermediate} />
+
+## Disabled
+
+<Canvas of={stories.Disabled} />
+
+## Error
+
+<Canvas of={stories.Error} />

--- a/packages/documentation/src/elements/checkbox/checkbox.stories.ts
+++ b/packages/documentation/src/elements/checkbox/checkbox.stories.ts
@@ -4,48 +4,30 @@ import { renderIcon } from "../icon/icon.stories.js";
 
 interface CheckboxArgs {
   label: string;
+  disabled?: boolean;
+  checked?: boolean;
+  intermediate?: boolean;
   error?: boolean;
 }
 
 const meta: Meta<CheckboxArgs> = {
   args: {
     label: "Checkbox",
-    error: false,
+    disabled: false,
+    checked: false,
+    intermediate: false,
   },
-  argTypes: {},
-
   render: (args) => html`
-    <div style="display:flex;gap:0.5rem;flex-direction:column;padding:2rem">
-      <div class="hap-checkbox ${args.error ? "hap-critical" : ""}">
-        <input type="checkbox" id="checkbox" />
-        ${renderIcon("check")}
-        <label for="checkbox5">
-          ${args.error ? renderIcon("circle-alert") : ""} ${args.label} default
-        </label>
-      </div>
-      <div class="hap-checkbox ${args.error ? "hap-critical" : ""}">
-        <input type="checkbox" id="checkbox2" checked />
-        ${renderIcon("check")}
-        <label for="checkbox5">
-          ${args.error ? renderIcon("circle-alert") : ""} ${args.label} checked
-        </label>
-      </div>
-      <div class="hap-checkbox ${args.error ? "hap-critical" : ""}">
-        <input type="checkbox" id="checkbox3" checked />
-        ${renderIcon("minus")}
-        <label for="checkbox5">
-          ${args.error ? renderIcon("circle-alert") : ""} ${args.label}
-          indeterminate
-        </label>
-      </div>
-      <div class="hap-checkbox ${args.error ? "hap-critical" : ""}">
-        <input type="checkbox" id="checkbox4" checked disabled />
-        ${renderIcon("check")}
-        <label for="checkbox5">
-          ${args.error ? renderIcon("circle-alert") : ""} ${args.label} disabled
-        </label>
-      </div>
-    </div>
+    <label class="hap-checkbox">
+      <input
+        type="checkbox"
+        name="confirmation"
+        ?disabled=${args.disabled}
+        ?checked=${args.checked}
+        .indeterminate=${args.intermediate ?? false}
+      />
+      <span>${args.label}</span>
+    </label>
   `,
 };
 
@@ -56,6 +38,27 @@ export const Default: Story = {
   args: { label: "Default" },
 };
 
+export const Intermediate: Story = {
+  args: { label: "Intermediate", intermediate: true },
+};
+
+export const Disabled: Story = {
+  args: { label: "Disabled", disabled: true },
+};
+
 export const Error: Story = {
-  args: { label: "Error", error: true },
+  args: { label: "Error" },
+  render: (args) => html`
+    <label class="hap-checkbox hap-checkbox--invalid">
+      <input
+        type="checkbox"
+        name="confirmation"
+        ?disabled=${args.disabled}
+        ?checked=${args.checked}
+        .indeterminate=${args.intermediate ?? false}
+      />
+      ${renderIcon("circle-alert", "small")}
+      <span>${args.label}</span>
+    </label>
+  `,
 };

--- a/packages/foundation/src/elements/checkbox.css
+++ b/packages/foundation/src/elements/checkbox.css
@@ -75,7 +75,7 @@
     content: "";
     inline-size: inherit;
     block-size: inherit;
-    background-color: white;
+    background-color: var(--hap-color-fill-input-default);
 
     mask-size: contain;
     mask-repeat: no-repeat;

--- a/packages/foundation/src/elements/checkbox.css
+++ b/packages/foundation/src/elements/checkbox.css
@@ -1,130 +1,94 @@
 .hap-checkbox {
+  --hap-checkbox-color-text: light-dark(
+    var(--hap-color-text-primary-on-light),
+    var(--hap-color-text-primary-on-dark)
+  );
+  --hap-checkbox-color: light-dark(
+    var(--hap-color-border-brand-on-light-default),
+    var(--hap-color-border-brand-on-dark-default)
+  );
+
+  color: var(--hap-checkbox-color-text);
   font-family: var(--hap-typography-font-family-body);
   font-size: var(--hap-typography-font-size-bodytext-s);
   font-weight: var(--hap-typography-font-weight-medium);
   letter-spacing: var(--hap-typography-letter-spacing-lg);
   line-height: var(--hap-typography-line-height-bodytext-s-singleline);
+
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--hap-spacing-sm);
-  height: var(--hap-size-lg);
-  width: var(--hap-size-lg);
-  position: relative;
+  gap: var(--hap-spacing-xs);
+  cursor: pointer;
 
-  input[type="checkbox"] {
-    appearance: none;
-    flex: 1 0 auto;
-    height: calc(var(--hap-size-lg) - 2 * 3px);
-    width: calc(var(--hap-size-lg) - 2 * 3px);
-    /* TODO: create token for clickable area */
-    margin: 3px;
-    background-color: var(--hap-color-fill-input-default);
-    border-style: solid;
-    border-color: var(--hap-color-border-brand-on-light-default);
-    border-width: var(--hap-border-width-md);
-    border-radius: var(--hap-radius-minimal);
-
-    &:not(:checked) ~ svg {
-      display: none;
-    }
-
-    &:checked {
-      background-color: var(--hap-color-fill-brand-on-light-default);
-
-      & ~ svg {
-        position: absolute;
-        display: block;
-        height: var(--hap-size-sm);
-        width: var(--hap-size-sm);
-        left: 4px;
-        pointer-events: none;
-      }
-    }
-
-    &::after {
-      display: none;
-      content: "";
-      position: absolute;
-      width: 40px;
-      height: 40px;
-      border-radius: 50%;
-      left: -8px;
-      top: -8px;
-    }
-
-    &:hover:not(:disabled) {
-      &::after {
-        display: block;
-        background-color: var(--hap-color-fill-interaction-on-light-hovered);
-      }
-    }
-
-    &:active:not(:disabled) {
-      &::after {
-        display: block;
-        background-color: var(--hap-color-fill-interaction-on-light-pressed);
-      }
-    }
-
-    &:focus-visible {
-      outline: none;
-
-      &::after {
-        display: block;
-        border-color: var(--hap-color-border-focused-default);
-        border-width: var(--hap-border-width-md);
-        border-style: solid;
-        width: 36px;
-        height: 36px;
-      }
-    }
-
-    &:disabled {
-      opacity: var(--hap-opacity-disabled);
-
-      & ~ label {
-        opacity: var(--hap-opacity-disabled);
-      }
-    }
+  &:has(input:disabled) {
+    opacity: var(--hap-opacity-disabled);
+    pointer-events: none;
   }
 
-  svg {
-    width: var(--hap-size-md);
-    color: var(--hap-color-icon-primary-on-dark);
-    /* stroke width is only a workaround here to make up for the scaling */
-    stroke-width: 2.5;
+  &:has(input:user-invalid),
+  &.hap-checkbox--invalid {
+    --hap-checkbox-color: light-dark(
+      var(--hap-color-feedback-critical-dark),
+      var(--hap-color-feedback-critical-light)
+    );
+    --hap-checkbox-color-text: light-dark(
+      var(--hap-color-feedback-critical-dark),
+      var(--hap-color-feedback-critical-light)
+    );
+  }
+}
+
+.hap-checkbox > input {
+  box-sizing: border-box;
+  appearance: none;
+  display: grid;
+  place-content: center;
+  cursor: pointer;
+
+  color: var(--hap-checkbox-color);
+  border-radius: var(--hap-radius-minimal);
+  border: var(--hap-border-width-md) solid currentColor;
+
+  /* has no custom property... */
+  inline-size: calc(var(--hap-size-lg) - 2 * 3px);
+  block-size: calc(var(--hap-size-lg) - 2 * 3px);
+  margin: 3px;
+
+  &:hover {
+    background-color: var(--hap-color-fill-interaction-on-light-hovered);
   }
 
-  label {
-    flex: 1 0 auto;
+  &:focus-visible {
+    outline: var(--hap-border-width-md) solid;
+    outline-color: var(--hap-color-border-focused-default);
+    outline-offset: var(--hap-border-width-sm);
   }
 
-  &.hap-critical {
-    color: var(--hap-color-feedback-critical-dark);
+  &:checked,
+  &:indeterminate {
+    background-color: currentColor;
+  }
 
-    input[type="checkbox"] {
-      border-color: var(--hap-color-feedback-critical-dark);
+  &::after {
+    display: none;
+    content: "";
+    inline-size: inherit;
+    block-size: inherit;
+    background-color: white;
 
-      &:checked {
-        background-color: var(--hap-color-feedback-critical-dark);
-      }
-    }
+    mask-size: contain;
+    mask-repeat: no-repeat;
+    mask-position: center;
+  }
 
-    svg {
-      color: var(--hap-color-feedback-critical-light);
-    }
+  &:checked::after {
+    display: block;
+    mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWNoZWNrLWljb24gbHVjaWRlLWNoZWNrIj48cGF0aCBkPSJNMjAgNiA5IDE3bC01LTUiLz48L3N2Zz4=);
+  }
 
-    label {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-
-      svg {
-        display: inline;
-        color: var(--hap-color-feedback-critical-dark);
-        stroke-width: 2;
-      }
-    }
+  &:indeterminate::after {
+    display: block;
+    mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW1pbnVzLWljb24gbHVjaWRlLW1pbnVzIj48cGF0aCBkPSJNNSAxMmgxNCIvPjwvc3ZnPg==);
   }
 }

--- a/packages/foundation/src/elements/checkbox.css
+++ b/packages/foundation/src/elements/checkbox.css
@@ -84,11 +84,13 @@
 
   &:checked::after {
     display: block;
+    /* Data URL for "check" icon: https://lucide.dev/icons/check */
     mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWNoZWNrLWljb24gbHVjaWRlLWNoZWNrIj48cGF0aCBkPSJNMjAgNiA5IDE3bC01LTUiLz48L3N2Zz4=);
   }
 
   &:indeterminate::after {
     display: block;
+    /* Data URL for "minus" icon: https://lucide.dev/icons/minus */
     mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW1pbnVzLWljb24gbHVjaWRlLW1pbnVzIj48cGF0aCBkPSJNNSAxMmgxNCIvPjwvc3ZnPg==);
   }
 }

--- a/packages/foundation/src/elements/radio-group.css
+++ b/packages/foundation/src/elements/radio-group.css
@@ -53,9 +53,6 @@
 }
 
 .hap-radio {
-  --hap-radio-border-width: 2px;
-  --hap-radio-size: var(--hap-size-lg);
-
   color: var(--hap-radio-color-text);
   font-family: var(--hap-typography-font-family-body);
   font-size: var(--hap-typography-font-size-bodytext-s);
@@ -79,10 +76,10 @@
 
   color: var(--hap-radio-color-border);
   border-radius: 100%;
-  border: var(--hap-radio-border-width) solid currentColor;
+  border: var(--hap-border-width-md) solid currentColor;
   /* has no custom property... */
-  inline-size: calc(var(--hap-radio-size) - 2 * 3px);
-  block-size: calc(var(--hap-radio-size) - 2 * 3px);
+  inline-size: calc(var(--hap-size-lg) - 2 * 3px);
+  block-size: calc(var(--hap-size-lg) - 2 * 3px);
   margin: 3px;
 
   &:hover {
@@ -91,9 +88,9 @@
 
   &:focus-visible {
     z-index: 1;
-    outline: var(--hap-radio-border-width) solid;
+    outline: var(--hap-border-width-md) solid;
     outline-color: var(--hap-color-border-focused-default);
-    outline-offset: 1px;
+    outline-offset: var(--hap-border-width-sm);
   }
 
   &:checked::before {


### PR DESCRIPTION
Im Design sind die Icons in der Checkbox als "Shape Substract" Maske angedacht. Dadurch schimmert der Hover Background (welcher hauptsächlich aus einer dunklen Opacity besteht) ganz leicht durch. Nach stundenlangen probieren, habe ich es nicht hinbekommen ein tatsächliches "Shape Loch" in die Checkbox oder einen Overlay zu cutten. Dadurch hat die Implementierung aktuell keinen durch-schimmernden Hover-Effekt bei einer "checked" oder "indeterminate" Checkbox.

closes #143 
