### PR TITLE
feat(search): adjust the height of search elements

### DIFF
--- a/.changeset/witty-maps-check.md
+++ b/.changeset/witty-maps-check.md
@@ -1,0 +1,5 @@
+---
+"@holisticon/hap-foundation": minor
+---
+
+Adjusted the height of search elements to have the same height as textfields.

--- a/packages/foundation/src/elements/search.css
+++ b/packages/foundation/src/elements/search.css
@@ -11,8 +11,7 @@
   box-sizing: border-box;
   transition: all 150ms linear;
   border-radius: var(--hap-radius-full);
-  padding-inline-start: var(--hap-spacing-sm);
-  padding-inline-end: var(--hap-spacing-xs);
+  padding-inline: var(--hap-spacing-sm);
 
   border: none;
   box-shadow: inset 0 0 0 var(--hap-textfield-border-width)
@@ -49,7 +48,7 @@
   background: none;
   padding: 0;
   flex: 1;
-  height: var(--hap-size-xl);
+  height: var(--hap-size-2xl);
 
   font-family: var(--hap-typography-font-family-body);
   font-size: var(--hap-typography-font-size-bodytext-s);


### PR DESCRIPTION
Mario noticed that the search element cannot be used next to textfields due to different heights. To adress this, the height of search elements has been adjusted.