### PR TITLE
chore: add missing storybook 9 migration for menu

### DIFF
--- a/packages/documentation/src/elements/menu/menu.mdx
+++ b/packages/documentation/src/elements/menu/menu.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
 import * as stories from "./menu.stories.ts";
 
 <Meta of={stories} />

--- a/packages/documentation/src/elements/menu/menu.stories.ts
+++ b/packages/documentation/src/elements/menu/menu.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/web-components";
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import { html } from "lit";
 import { renderIcon } from "../icon/icon.stories.js";
 


### PR DESCRIPTION
The menu was merged in-between the Storybook v9 update, and I forgot to rebase the update branch shortly before merging... This fixes the broken pipeline.