### PR TITLE
fix(topbar): explicit active style and pressed style

### DIFF
--- a/packages/documentation/src/elements/topbar/topbar.stories.ts
+++ b/packages/documentation/src/elements/topbar/topbar.stories.ts
@@ -12,7 +12,9 @@ export const Default: Story = {
     html`<div class="hap-topbar">
       <div class="hap-headline-sm">FANCY LOGO</div>
       <nav class="hap-topbar-nav">
-        <a class="hap-topbar-nav-item" href="#">Link 1</a>
+        <a class="hap-topbar-nav-item hap-topbar-nav-item--active" href="#"
+          >Link 1</a
+        >
         <a class="hap-topbar-nav-item" href="#">Link 2</a>
         <a class="hap-topbar-nav-item" href="#">Link 3</a>
         <a class="hap-topbar-nav-item hap-topbar-nav-item--disabled" href="#">

--- a/packages/foundation/src/elements/topbar.css
+++ b/packages/foundation/src/elements/topbar.css
@@ -41,13 +41,17 @@
   }
 
   &:active::after {
-    background-color: currentColor;
+    background-color: transparent;
   }
 
   &:focus-visible {
     outline: var(--hap-border-width-md) solid
       var(--hap-color-border-focused-default);
   }
+}
+
+.hap-topbar-nav-item--active::after {
+  background-color: var(--hap-color-text-brand-on-light);
 }
 
 .hap-topbar-nav-item--disabled {


### PR DESCRIPTION
Vorher hätte "Active" das falsche Token verwendet und wurde auch nur über den `:active` Pseudostate gesteuert. Der mappt in der Verwendung eher auf die "Pressed" Figma Variante, und hätte für NavLinks auch gar nicht funktioniert. Der Style für eine aktive Seite sollte wohl besser explizit über eine Klasse gesteuert werden. Alternativ wäre noch das `aria-current="page"` Attribute denkbar.